### PR TITLE
Add initial example for nrf51 devkit

### DIFF
--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -19,3 +19,6 @@ version = "0.6.0"
 
 [target.'cfg(target_arch="arm")'.dependencies.cortex-m-rt]
 version = "0.6.13"
+
+[features]
+"isa+thumbv6" = []

--- a/arch/src/cortex_m/mod.rs
+++ b/arch/src/cortex_m/mod.rs
@@ -14,7 +14,7 @@ where
 
 // Copyright James Munns, original code copied from https://github.com/jamesmunns/bbqueue and modified to match
 // the atomic types used by drogue-device.
-#[cfg(feature = "thumbv6")]
+#[cfg(feature = "isa+thumbv6")]
 pub mod atomic {
     use core::sync::atomic::{
         AtomicBool, AtomicU8,
@@ -50,7 +50,7 @@ pub mod atomic {
     }
 }
 
-#[cfg(not(feature = "thumbv6"))]
+#[cfg(not(feature = "isa+thumbv6"))]
 pub mod atomic {
     use core::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 

--- a/examples/nrf52/microbit-rak811/Cargo.toml
+++ b/examples/nrf52/microbit-rak811/Cargo.toml
@@ -15,7 +15,7 @@ rtt-logger = "0.1.0"
 nb = "1.0.0"
 embedded-hal = { version = "0.2.3", features = ["unproven"] }
 void = { version = "1.0.2", default-features = false }
-drogue-device = { path = "../../../rt", features = ["nrf52833", "driver-rak811" ]}
+drogue-device = { path = "../../../rt", features = ["chip+nrf52833", "driver-rak811" ]}
 heapless = "0.5.5"
 
 [dependencies.nrf52833-hal]

--- a/examples/nrf52/microbit-uart/Cargo.toml
+++ b/examples/nrf52/microbit-uart/Cargo.toml
@@ -15,7 +15,7 @@ rtt-logger = "0.1.0"
 nb = "1.0.0"
 embedded-hal = { version = "0.2.3", features = ["unproven"] }
 void = { version = "1.0.2", default-features = false }
-drogue-device = { path = "../../../rt", features = ["nrf52833", "fonts"]}
+drogue-device = { path = "../../../rt", features = ["chip+nrf52833", "fonts"]}
 heapless = "0.5.5"
 
 [dependencies.nrf52833-hal]

--- a/rt/Cargo.toml
+++ b/rt/Cargo.toml
@@ -112,13 +112,10 @@ default-features = false
 [features]
 # let's deprecate these
 stm32l4xx = [ "stm32l4xx-hal" ]
-stm32l1xx = [ "stm32l1xx-hal" ]
-nrf52833 = [ "nrf52833-hal" ]
-thumbv6 = []
 
 "chip+stm32l4xx" = [ "stm32l4xx-hal" ]
 "chip+nrf52833" = [ "nrf52833-hal" ]
-"chip+nrf51" = [ "nrf51-hal", "bbqueue/thumbv6" ]
+"chip+nrf51" = [ "nrf51-hal", "bbqueue/thumbv6", "drogue-arch/isa+thumbv6" ]
 
 driver-rak811 = [ "drogue-rak811" ]
 fonts = []

--- a/rt/src/platform/cortex_m/mod.rs
+++ b/rt/src/platform/cortex_m/mod.rs
@@ -5,11 +5,8 @@ pub mod stm32l4xx;
 pub mod stm32l1xx;
 
 #[cfg(any(
-    feature = "nrf51",
-    feature = "nrf52832",
-    feature = "nrf52833",
-    feature = "nrf52840",
-    feature = "nrf9160"
+    feature = "chip+nrf51",
+    feature = "chip+nrf52833",
 ))]
 pub mod nrf;
 

--- a/rt/src/platform/cortex_m/nrf/gpiote/mod.rs
+++ b/rt/src/platform/cortex_m/nrf/gpiote/mod.rs
@@ -1,10 +1,10 @@
 use crate::prelude::*;
 use embedded_hal::digital::v2::InputPin;
 
-#[cfg(feature = "nrf52833")]
+#[cfg(feature = "chip+nrf52833")]
 use nrf52833_hal as hal;
 
-#[cfg(feature = "nrf51")]
+#[cfg(feature = "chip+nrf51")]
 use nrf51_hal as hal;
 
 use hal::gpiote::GpioteInputPin;

--- a/rt/src/platform/cortex_m/nrf/timer.rs
+++ b/rt/src/platform/cortex_m/nrf/timer.rs
@@ -1,8 +1,8 @@
 //! Timers for nRF series
-#[cfg(feature = "nrf52833")]
+#[cfg(feature = "chip+nrf52833")]
 use nrf52833_hal as hal;
 
-#[cfg(feature = "nrf51")]
+#[cfg(feature = "chip+nrf51")]
 use nrf51_hal as hal;
 
 use crate::domain::time::{

--- a/rt/src/platform/cortex_m/nrf/uarte.rs
+++ b/rt/src/platform/cortex_m/nrf/uarte.rs
@@ -1,15 +1,15 @@
 //! Uart implementation for nRF series
-#[cfg(feature = "nrf52833")]
+#[cfg(feature = "chip+nrf52833")]
 use nrf52833_hal as hal;
 
 #[allow(unused_imports)]
-#[cfg(any(feature = "nrf52833", feature = "nrf52840"))]
+#[cfg(any(feature = "chip+nrf52833", feature = "chip+nrf52840"))]
 use hal::pac::UARTE1;
 
-#[cfg(feature = "nrf9160")]
+#[cfg(feature = "chip+nrf9160")]
 use hal::pac::{uarte0_ns as uarte0, UARTE0_NS as UARTE0, UARTE1_NS as UARTE1};
 
-#[cfg(not(feature = "nrf9160"))]
+#[cfg(not(feature = "chip+nrf9160"))]
 use hal::pac::uarte0;
 
 use crate::api::uart::Error;
@@ -392,7 +392,7 @@ fn slice_in_ram(slice: &[u8]) -> bool {
 }
 
 /// Return an error if slice is not in RAM.
-#[cfg(not(feature = "51"))]
+#[cfg(not(feature = "chip+nrf51"))]
 pub(crate) fn slice_in_ram_or<T>(slice: &[u8], err: T) -> Result<(), T> {
     if slice_in_ram(slice) {
         Ok(())


### PR DESCRIPTION
* Rename thumbv6 -> isa+thumbv6
* Use chip+nrf51 and chip+nrf52833 instead of old format
* Only support chips we know will work