### PR TITLE
Split sx127x driver into actor and controller

### DIFF
--- a/examples/stm32l0/lora-discovery/src/main.rs
+++ b/examples/stm32l0/lora-discovery/src/main.rs
@@ -59,7 +59,7 @@ fn get_random_u32() -> u32 {
 }
 
 fn configure() -> MyDevice {
-    rtt_init_print!();
+    rtt_init_print!(BlockIfFull, 1024);
     unsafe {
         log::set_logger_racy(&LOGGER).unwrap();
     }
@@ -135,5 +135,5 @@ fn configure() -> MyDevice {
 
 #[entry]
 fn main() -> ! {
-    device!(MyDevice = configure; 4096);
+    device!(MyDevice = configure; 3000);
 }

--- a/rt/src/api/lora.rs
+++ b/rt/src/api/lora.rs
@@ -7,20 +7,36 @@ impl<A> Address<A>
 where
     A: LoraDriver,
 {
+    /// Configure the LoRa module with the provided config.
     pub async fn configure<'a>(&self, config: &'a LoraConfig) -> Result<(), LoraError> {
         self.request_panicking(Configure(config)).await
     }
 
+    /// Reset the LoRa module.
     pub async fn reset(&self, mode: ResetMode) -> Result<(), LoraError> {
         self.request(Reset(mode)).await
     }
 
+    /// Join a LoRaWAN network with the given connect mode.
     pub async fn join(&self, mode: ConnectMode) -> Result<(), LoraError> {
         self.request(Join(mode)).await
     }
 
+    /// Send data on a specific port with a given quality of service.
     pub async fn send<'a>(&self, qos: QoS, port: Port, data: &'a [u8]) -> Result<(), LoraError> {
         self.request_panicking(Send(qos, port, data)).await
+    }
+
+    /// Send data on a specific port with a given quality of service. If the LoRa module receives
+    /// any data as part of the confirmation, write it into the provided buffer and return the size of the data read.
+    pub async fn send_recv<'a>(
+        &self,
+        qos: QoS,
+        port: Port,
+        data: &'a [u8],
+        rx: &'a mut [u8],
+    ) -> Result<usize, LoraError> {
+        self.request_panicking(SendRecv(qos, port, data, rx)).await
     }
 }
 
@@ -29,7 +45,9 @@ pub enum LoraError {
     SendError,
     RecvError,
     RecvTimeout,
+    RecvBufferTooSmall,
     NotInitialized,
+    NotImplemented,
     OtherError,
 }
 
@@ -45,8 +63,13 @@ pub trait LoraDriver: Actor {
     /// Join a LoRaWAN network using the specified connect mode.
     fn join(self, message: Join) -> Response<Self, Result<(), LoraError>>;
 
-    /// Send telemetry data with a given Quality-of-Service on a specific platform.
+    /// Send data on a specific port with a given quality of service.
     fn send<'a>(self, message: Send<'a>) -> Response<Self, Result<(), LoraError>>;
+
+    /// Send data on a specific port with a given quality of service. If the LoRa module receives
+    /// any data as part of the confirmation, the command provides a buffer that the implementation
+    /// may write the data into. The number of bytes read should be returned.
+    fn send_recv<'a>(self, message: SendRecv<'a>) -> Response<Self, Result<usize, LoraError>>;
 }
 
 /// Message types and handlers for the LoraDriver trait.
@@ -60,7 +83,7 @@ pub struct Reset(pub ResetMode);
 #[derive(Debug)]
 pub struct Send<'a>(pub QoS, pub Port, pub &'a [u8]);
 #[derive(Debug)]
-pub struct Recv<'a>(pub &'a mut [u8]);
+pub struct SendRecv<'a>(pub QoS, pub Port, pub &'a [u8], pub &'a mut [u8]);
 
 impl<'a, A> RequestHandler<Configure<'a>> for A
 where
@@ -99,5 +122,15 @@ where
     type Response = Result<(), LoraError>;
     fn on_request(self, message: Send<'a>) -> Response<Self, Self::Response> {
         self.send(message)
+    }
+}
+
+impl<'a, A> RequestHandler<SendRecv<'a>> for A
+where
+    A: LoraDriver,
+{
+    type Response = Result<usize, LoraError>;
+    fn on_request(self, message: SendRecv<'a>) -> Response<Self, Self::Response> {
+        self.send_recv(message)
     }
 }

--- a/rt/src/driver/lora/rak811.rs
+++ b/rt/src/driver/lora/rak811.rs
@@ -315,6 +315,10 @@ where
             (self, result)
         })
     }
+
+    fn send_recv<'a>(mut self, message: SendRecv<'a>) -> Response<Self, Result<usize, LoraError>> {
+        Response::immediate(self, Err(LoraError::NotImplemented))
+    }
 }
 
 impl<U, Q> Rak811Ingress<U, Q>

--- a/rt/src/system/device.rs
+++ b/rt/src/system/device.rs
@@ -57,20 +57,19 @@ pub struct DeviceContext<D: Device + 'static> {
 
 impl<D: Device> DeviceContext<D> {
     pub fn new(device: D) -> Self {
-        log::info!("Creating..");
         let d = Self {
             //device: UnsafeCell::new(device),
             device,
             supervisor: RefCell::new(Supervisor::new()),
             bus: UnsafeCell::new(None),
         };
-        log::info!("Size of device context is {}", core::mem::size_of_val(&d));
-        log::info!("Size of device is {}", core::mem::size_of_val(&d.device));
-        log::info!(
-            "Size of supervisor is {}",
-            core::mem::size_of_val(&d.supervisor)
-        );
-        log::info!("Size of bus is {}", core::mem::size_of_val(&d.bus));
+        //log::info!("Size of device context is {}", core::mem::size_of_val(&d));
+        //log::info!("Size of device is {}", core::mem::size_of_val(&d.device));
+        //log::info!(
+        //    "Size of supervisor is {}",
+        //    core::mem::size_of_val(&d.supervisor)
+        //);
+        //log::info!("Size of bus is {}", core::mem::size_of_val(&d.bus));
         d
     }
 


### PR DESCRIPTION
Split driver into an "actor", "controller", and "interrupt" component.

The interrupt component receives interrupts and passes on the appropriate
event to the controller component.

The controller component receives messages from interrupt and timers and
provides responses to commands issues by the actor component.

The actor component forwards commands to the controller components and
awaits the state processing to complete before responding to the user.

Implement receive in LoRa API