### PR TITLE
Pin stm32f4xx-hal to version 0.9

### DIFF
--- a/examples/stm32f4/esp8266/Cargo.toml
+++ b/examples/stm32f4/esp8266/Cargo.toml
@@ -14,10 +14,7 @@ rtt-target = {version = "0.2.2", features = ["cortex-m"] }
 panic-rtt-target = { version = "0.1.1", features = ["cortex-m"] }
 rtt-logger = "0.1.0"
 log = "0.4.11"
-stm32f4xx-hal = { version = "0.8", features = ["stm32f401", "rt" ] }
-
-[patch.crates-io]
-stm32f4xx-hal = { git = "https://github.com/stm32-rs/stm32f4xx-hal" }
+stm32f4xx-hal = { version = "0.9", features = ["stm32f401", "rt" ] }
 
 [profile.release]
 debug = true

--- a/rt/Cargo.toml
+++ b/rt/Cargo.toml
@@ -62,7 +62,7 @@ version = "1.0.0"
 version = "0.4"
 
 [dependencies.stm32f4xx-hal]
-version = "0.8"
+version = "0.9"
 optional = true
 
 [dependencies.stm32l4xx-hal]


### PR DESCRIPTION
This (hopefully) fixes CI by pinning the stm32f4xx-hal version is the most recent released (April 5th).

@jcrossley3 Could you check if the example still works? 