### PR TITLE
Add build-std = core to .cargo/config.toml's

### DIFF
--- a/examples/nrf52/microbit-esp8266/.cargo/config
+++ b/examples/nrf52/microbit-esp8266/.cargo/config
@@ -1,3 +1,6 @@
+[unstable]
+build-std = ["core"]
+
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
 runner = "probe-run --chip nrf52833_xxAA"
 

--- a/examples/nrf52/microbit-rak811/.cargo/config
+++ b/examples/nrf52/microbit-rak811/.cargo/config
@@ -1,3 +1,6 @@
+[unstable]
+build-std = ["core"]
+
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
 runner = "probe-run --chip nrf52833_xxAA"
 

--- a/examples/nrf52/microbit-uart/.cargo/config
+++ b/examples/nrf52/microbit-uart/.cargo/config
@@ -1,3 +1,6 @@
+[unstable]
+build-std = ["core"]
+
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
 runner = "probe-run --chip nrf52833_xxAA"
 

--- a/examples/stm32l0xx/.cargo/config
+++ b/examples/stm32l0xx/.cargo/config
@@ -1,3 +1,6 @@
+[unstable]
+build-std = ["core"]
+
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
 runner = "probe-run --chip STM32L072CZ"
 


### PR DESCRIPTION
This is what is done in embassy's .cargo/config.toml's
And we already have the required "rust-src" component pulled in by the rust-toolchain.toml file.

This change reduces the size of the binary of the micro-bit-esp8266 example from 778K to 170K