### PR TITLE
Create generic WiFi actor abstractions

### DIFF
--- a/device/src/actors/mod.rs
+++ b/device/src/actors/mod.rs
@@ -2,3 +2,4 @@ pub mod button;
 pub mod led;
 pub mod ticker;
 pub mod timer;
+pub mod wifi;

--- a/device/src/actors/wifi/esp8266/mod.rs
+++ b/device/src/actors/wifi/esp8266/mod.rs
@@ -1,0 +1,135 @@
+use super::AdapterActor;
+use crate::drivers::wifi::esp8266::*;
+use crate::kernel::{
+    actor::{Actor, ActorContext, ActorSpawner, Address},
+    package::*,
+};
+use core::{
+    cell::{RefCell, UnsafeCell},
+    future::Future,
+    pin::Pin,
+};
+use embassy::io::{AsyncBufReadExt, AsyncWriteExt};
+use embedded_hal::digital::v2::OutputPin;
+
+pub enum State<UART, ENABLE, RESET>
+where
+    UART: AsyncBufReadExt + AsyncWriteExt + 'static,
+    ENABLE: OutputPin + 'static,
+    RESET: OutputPin + 'static,
+{
+    New(UART, ENABLE, RESET),
+    Initialized,
+}
+
+pub struct Esp8266Wifi<UART, ENABLE, RESET>
+where
+    UART: AsyncBufReadExt + AsyncWriteExt + 'static,
+    ENABLE: OutputPin + 'static,
+    RESET: OutputPin + 'static,
+{
+    driver: UnsafeCell<Esp8266Driver>,
+    state: RefCell<Option<State<UART, ENABLE, RESET>>>,
+    wifi: ActorContext<'static, AdapterActor<Esp8266Controller<'static>>>,
+    modem: ActorContext<'static, ModemActor<'static, UART, ENABLE, RESET>>,
+}
+
+impl<UART, ENABLE, RESET> Esp8266Wifi<UART, ENABLE, RESET>
+where
+    UART: AsyncBufReadExt + AsyncWriteExt + 'static,
+    ENABLE: OutputPin + 'static,
+    RESET: OutputPin + 'static,
+{
+    pub fn new(uart: UART, enable: ENABLE, reset: RESET) -> Self {
+        Self {
+            driver: UnsafeCell::new(Esp8266Driver::new()),
+            state: RefCell::new(Some(State::New(uart, enable, reset))),
+            wifi: ActorContext::new(AdapterActor::new()),
+            modem: ActorContext::new(ModemActor::new()),
+        }
+    }
+}
+
+impl<UART, ENABLE, RESET> Package for Esp8266Wifi<UART, ENABLE, RESET>
+where
+    UART: AsyncBufReadExt + AsyncWriteExt + 'static,
+    ENABLE: OutputPin + 'static,
+    RESET: OutputPin + 'static,
+{
+    type Primary = AdapterActor<Esp8266Controller<'static>>;
+
+    fn mount<S: ActorSpawner>(
+        &'static self,
+        _: Self::Configuration,
+        spawner: S,
+    ) -> Address<Self::Primary> {
+        if let Some(State::New(uart, enable, reset)) = self.state.borrow_mut().take() {
+            let (controller, modem) =
+                unsafe { &mut *self.driver.get() }.initialize(uart, enable, reset);
+            self.modem.mount(modem, spawner);
+            self.wifi.mount(controller, spawner)
+        } else {
+            panic!("Attempted to mount package twice!")
+        }
+    }
+}
+
+/// Convenience actor implementation of modem
+pub struct ModemActor<'a, UART, ENABLE, RESET>
+where
+    UART: AsyncBufReadExt + AsyncWriteExt + 'static,
+    ENABLE: OutputPin + 'static,
+    RESET: OutputPin + 'static,
+{
+    modem: Option<Esp8266Modem<'a, UART, ENABLE, RESET>>,
+}
+
+impl<'a, UART, ENABLE, RESET> ModemActor<'a, UART, ENABLE, RESET>
+where
+    UART: AsyncBufReadExt + AsyncWriteExt + 'static,
+    ENABLE: OutputPin + 'static,
+    RESET: OutputPin + 'static,
+{
+    pub fn new() -> Self {
+        Self { modem: None }
+    }
+}
+
+impl<'a, UART, ENABLE, RESET> Unpin for ModemActor<'a, UART, ENABLE, RESET>
+where
+    UART: AsyncBufReadExt + AsyncWriteExt + 'static,
+    ENABLE: OutputPin + 'static,
+    RESET: OutputPin + 'static,
+{
+}
+
+impl<'a, UART, ENABLE, RESET> Actor for ModemActor<'a, UART, ENABLE, RESET>
+where
+    UART: AsyncBufReadExt + AsyncWriteExt + 'static,
+    ENABLE: OutputPin + 'static,
+    RESET: OutputPin + 'static,
+{
+    type Configuration = Esp8266Modem<'a, UART, ENABLE, RESET>;
+    #[rustfmt::skip]
+    type Message<'m> where 'a: 'm = ();
+
+    fn on_mount(&mut self, config: Self::Configuration) {
+        self.modem.replace(config);
+    }
+
+    #[rustfmt::skip]
+    type OnStartFuture<'m> where 'a: 'm = impl Future<Output = ()> + 'm;
+    fn on_start(mut self: Pin<&'_ mut Self>) -> Self::OnStartFuture<'_> {
+        async move {
+            self.modem.as_mut().unwrap().run().await;
+        }
+    }
+
+    #[rustfmt::skip]
+    type OnMessageFuture<'m> where 'a: 'm = impl Future<Output = ()> + 'm;
+    fn on_message<'m>(self: Pin<&'m mut Self>, _: Self::Message<'m>) -> Self::OnMessageFuture<'m> {
+        async move {}
+    }
+}
+
+impl<'a> super::Adapter for Esp8266Controller<'a> {}

--- a/device/src/actors/wifi/mod.rs
+++ b/device/src/actors/wifi/mod.rs
@@ -1,0 +1,225 @@
+use crate::{
+    kernel::actor::{Actor, Address},
+    traits::{
+        ip::{IpAddress, IpProtocol, SocketAddress},
+        tcp::{TcpError, TcpStack},
+        wifi::{Join, JoinError, WifiSupplicant},
+    },
+};
+
+use core::future::Future;
+use core::pin::Pin;
+
+#[cfg(feature = "wifi+esp8266")]
+pub mod esp8266;
+
+/// Actor messages handled by network adapter actors
+pub enum AdapterRequest<'m> {
+    Join(Join<'m>),
+    Open,
+    Connect(u8, IpProtocol, SocketAddress),
+    Send(u8, &'m [u8]),
+    Recv(u8, &'m mut [u8]),
+    Close(u8),
+}
+
+/// Actor responses returned by network adapter actors
+pub enum AdapterResponse {
+    Join(Result<IpAddress, JoinError>),
+    Open(u8),
+    Connect(Result<(), TcpError>),
+    Send(Result<usize, TcpError>),
+    Recv(Result<usize, TcpError>),
+    Close,
+}
+
+pub trait Adapter: WifiSupplicant + TcpStack<SocketHandle = u8> {}
+
+/// Wrapper for a Wifi adapter.
+pub struct WifiAdapter<'a, A>
+where
+    A: Adapter + 'static,
+{
+    address: Address<'a, AdapterActor<A>>,
+}
+
+impl<'a, A> WifiAdapter<'a, A>
+where
+    A: Adapter + 'static,
+{
+    pub fn new(address: Address<'a, AdapterActor<A>>) -> Self {
+        Self { address }
+    }
+
+    pub async fn join<'m>(&'m self, join_info: Join<'m>) -> Result<IpAddress, JoinError> {
+        self.address
+            .request(AdapterRequest::Join(join_info))
+            .unwrap()
+            .await
+            .join()
+    }
+
+    pub async fn socket<'m>(&'m self) -> Socket<'a, A> {
+        let handle = self
+            .address
+            .request(AdapterRequest::Open)
+            .unwrap()
+            .await
+            .open();
+        Socket::new(self.address, handle)
+    }
+}
+
+/// A Socket type for connecting to a network endpoint + sending and receiving data.
+pub struct Socket<'a, A>
+where
+    A: Adapter + 'static,
+{
+    address: Address<'a, AdapterActor<A>>,
+    handle: u8,
+}
+
+impl<'a, A> Socket<'a, A>
+where
+    A: Adapter + 'static,
+{
+    pub fn new(address: Address<'a, AdapterActor<A>>, handle: u8) -> Self {
+        Self { address, handle }
+    }
+
+    pub async fn connect<'m>(
+        &'m self,
+        proto: IpProtocol,
+        dst: SocketAddress,
+    ) -> Result<(), TcpError> {
+        self.address
+            .request(AdapterRequest::Connect(self.handle, proto, dst))
+            .unwrap()
+            .await
+            .connect()
+    }
+
+    pub async fn send<'m>(&'m self, buf: &'m [u8]) -> Result<usize, TcpError> {
+        self.address
+            .request(AdapterRequest::Send(self.handle, buf))
+            .unwrap()
+            .await
+            .send()
+    }
+
+    pub async fn recv<'m>(&'m self, buf: &'m mut [u8]) -> Result<usize, TcpError> {
+        self.address
+            .request(AdapterRequest::Recv(self.handle, buf))
+            .unwrap()
+            .await
+            .recv()
+    }
+
+    pub async fn close<'m>(&'m self) {
+        self.address
+            .request(AdapterRequest::Close(self.handle))
+            .unwrap()
+            .await;
+    }
+}
+
+impl AdapterResponse {
+    fn open(self) -> u8 {
+        match self {
+            AdapterResponse::Open(handle) => handle,
+            _ => panic!("unexpected response type"),
+        }
+    }
+
+    fn join(self) -> Result<IpAddress, JoinError> {
+        match self {
+            AdapterResponse::Join(result) => result,
+            _ => panic!("unexpected response type"),
+        }
+    }
+
+    fn connect(self) -> Result<(), TcpError> {
+        match self {
+            AdapterResponse::Connect(result) => result,
+            _ => panic!("unexpected response type"),
+        }
+    }
+
+    fn send(self) -> Result<usize, TcpError> {
+        match self {
+            AdapterResponse::Send(result) => result,
+            _ => panic!("unexpected response type"),
+        }
+    }
+
+    fn recv(self) -> Result<usize, TcpError> {
+        match self {
+            AdapterResponse::Recv(result) => result,
+            _ => panic!("unexpected response type"),
+        }
+    }
+
+    fn close(self) {
+        match self {
+            AdapterResponse::Close => (),
+            _ => panic!("unexpected response type"),
+        }
+    }
+}
+
+pub struct AdapterActor<N: Adapter> {
+    driver: Option<N>,
+}
+
+impl<N: Adapter> AdapterActor<N> {
+    pub fn new() -> Self {
+        Self { driver: None }
+    }
+}
+
+impl<N: Adapter> Actor for AdapterActor<N> {
+    type Configuration = N;
+
+    #[rustfmt::skip]
+    type Message<'m> where N: 'm = AdapterRequest<'m>;
+    type Response = AdapterResponse;
+
+    fn on_mount(&mut self, config: Self::Configuration) {
+        self.driver.replace(config);
+    }
+
+    #[rustfmt::skip]
+    type OnStartFuture<'m> where N: 'm = impl Future<Output = ()> + 'm;
+    fn on_start(self: Pin<&'_ mut Self>) -> Self::OnStartFuture<'_> {
+        async move {}
+    }
+
+    #[rustfmt::skip]
+    type OnMessageFuture<'m> where N: 'm = impl Future<Output = Self::Response> + 'm;
+    fn on_message<'m>(
+        self: Pin<&'m mut Self>,
+        message: Self::Message<'m>,
+    ) -> Self::OnMessageFuture<'m> {
+        async move {
+            let this = unsafe { self.get_unchecked_mut() };
+            let driver = this.driver.as_mut().unwrap();
+            match message {
+                AdapterRequest::Join(join) => AdapterResponse::Join(driver.join(join).await),
+                AdapterRequest::Open => AdapterResponse::Open(driver.open().await),
+                AdapterRequest::Connect(handle, proto, addr) => {
+                    AdapterResponse::Connect(driver.connect(handle, proto, addr).await)
+                }
+                AdapterRequest::Send(handle, buf) => {
+                    AdapterResponse::Send(driver.write(handle, buf).await)
+                }
+                AdapterRequest::Recv(handle, buf) => {
+                    AdapterResponse::Recv(driver.read(handle, buf).await)
+                }
+                AdapterRequest::Close(handle) => {
+                    driver.close(handle).await;
+                    AdapterResponse::Close
+                }
+            }
+        }
+    }
+}

--- a/device/src/drivers/wifi/esp8266/mod.rs
+++ b/device/src/drivers/wifi/esp8266/mod.rs
@@ -12,7 +12,7 @@ mod socket_pool;
 use socket_pool::SocketPool;
 
 use crate::{
-    kernel::{actor::Actor, channel::*},
+    kernel::channel::*,
     traits::{
         ip::{IpAddress, IpProtocol, SocketAddress},
         tcp::{TcpError, TcpStack},
@@ -26,7 +26,7 @@ use core::{
     sync::atomic::{AtomicBool, Ordering},
 };
 use embassy::{
-    io::{AsyncBufRead, AsyncBufReadExt, AsyncWrite, AsyncWriteExt},
+    io::{AsyncBufReadExt, AsyncWriteExt},
     util::Signal,
 };
 use embedded_hal::digital::v2::OutputPin;
@@ -87,7 +87,7 @@ pub struct Esp8266Controller<'a> {
 
 pub struct Esp8266Modem<'a, UART, ENABLE, RESET>
 where
-    UART: AsyncBufRead + AsyncBufReadExt + AsyncWrite + AsyncWriteExt + 'static,
+    UART: AsyncBufReadExt + AsyncWriteExt + 'static,
     ENABLE: OutputPin + 'static,
     RESET: OutputPin + 'static,
 {
@@ -125,7 +125,7 @@ impl Esp8266Driver {
         reset: RESET,
     ) -> (Esp8266Controller<'a>, Esp8266Modem<'a, UART, ENABLE, RESET>)
     where
-        UART: AsyncBufRead + AsyncBufReadExt + AsyncWrite + AsyncWriteExt + 'static,
+        UART: AsyncBufReadExt + AsyncWriteExt + 'static,
         ENABLE: OutputPin + 'static,
         RESET: OutputPin + 'static,
     {
@@ -142,7 +142,7 @@ impl Esp8266Driver {
 
 impl<'a, UART, ENABLE, RESET> Esp8266Modem<'a, UART, ENABLE, RESET>
 where
-    UART: AsyncBufRead + AsyncBufReadExt + AsyncWrite + AsyncWriteExt + 'static,
+    UART: AsyncBufReadExt + AsyncWriteExt + 'static,
     ENABLE: OutputPin + 'static,
     RESET: OutputPin + 'static,
 {
@@ -593,7 +593,7 @@ impl<'a> TcpStack for Esp8266Controller<'a> {
 
 async fn uart_read<UART>(uart: &mut UART, rx_buf: &mut [u8]) -> Result<usize, embassy::io::Error>
 where
-    UART: AsyncBufRead + AsyncBufReadExt + 'static,
+    UART: AsyncBufReadExt + 'static,
 {
     let mut uart = unsafe { Pin::new_unchecked(uart) };
     uart.read(rx_buf).await
@@ -601,66 +601,8 @@ where
 
 async fn uart_write<UART>(uart: &mut UART, buf: &[u8]) -> Result<(), embassy::io::Error>
 where
-    UART: AsyncWriteExt + AsyncWrite + 'static,
+    UART: AsyncWriteExt + 'static,
 {
     let mut uart = unsafe { Pin::new_unchecked(uart) };
     uart.write_all(buf).await
-}
-
-/// Convenience actor implementation of modem
-pub struct Esp8266ModemActor<'a, UART, ENABLE, RESET>
-where
-    UART: AsyncBufRead + AsyncBufReadExt + AsyncWrite + AsyncWriteExt + 'static,
-    ENABLE: OutputPin + 'static,
-    RESET: OutputPin + 'static,
-{
-    modem: Option<Esp8266Modem<'a, UART, ENABLE, RESET>>,
-}
-
-impl<'a, UART, ENABLE, RESET> Esp8266ModemActor<'a, UART, ENABLE, RESET>
-where
-    UART: AsyncBufRead + AsyncBufReadExt + AsyncWrite + AsyncWriteExt + 'static,
-    ENABLE: OutputPin + 'static,
-    RESET: OutputPin + 'static,
-{
-    pub fn new() -> Self {
-        Self { modem: None }
-    }
-}
-
-impl<'a, UART, ENABLE, RESET> Unpin for Esp8266ModemActor<'a, UART, ENABLE, RESET>
-where
-    UART: AsyncBufRead + AsyncBufReadExt + AsyncWrite + AsyncWriteExt + 'static,
-    ENABLE: OutputPin + 'static,
-    RESET: OutputPin + 'static,
-{
-}
-
-impl<'a, UART, ENABLE, RESET> Actor for Esp8266ModemActor<'a, UART, ENABLE, RESET>
-where
-    UART: AsyncBufRead + AsyncBufReadExt + AsyncWrite + AsyncWriteExt + 'static,
-    ENABLE: OutputPin + 'static,
-    RESET: OutputPin + 'static,
-{
-    type Configuration = Esp8266Modem<'a, UART, ENABLE, RESET>;
-    #[rustfmt::skip]
-    type Message<'m> where 'a: 'm = ();
-
-    fn on_mount(&mut self, config: Self::Configuration) {
-        self.modem.replace(config);
-    }
-
-    #[rustfmt::skip]
-    type OnStartFuture<'m> where 'a: 'm = impl Future<Output = ()> + 'm;
-    fn on_start(mut self: Pin<&'_ mut Self>) -> Self::OnStartFuture<'_> {
-        async move {
-            self.modem.as_mut().unwrap().run().await;
-        }
-    }
-
-    #[rustfmt::skip]
-    type OnMessageFuture<'m> where 'a: 'm = impl Future<Output = ()> + 'm;
-    fn on_message<'m>(self: Pin<&'m mut Self>, _: Self::Message<'m>) -> Self::OnMessageFuture<'m> {
-        async move {}
-    }
 }

--- a/examples/nrf52/microbit-esp8266/src/main.rs
+++ b/examples/nrf52/microbit-esp8266/src/main.rs
@@ -29,7 +29,7 @@ use embassy_nrf::{
     gpio::{Input, Level, NoPin, Output, OutputDrive, Pull},
     gpiote::PortInput,
     interrupt,
-    peripherals::{P0_02, P0_03, P0_14, TIMER0, UARTE0},
+    peripherals::{P0_09, P0_10, P0_14, TIMER0, UARTE0},
     uarte, Peripherals,
 };
 
@@ -41,8 +41,8 @@ const PORT: u16 = 12345;
 static LOGGER: RTTLogger = RTTLogger::new(LevelFilter::Trace);
 
 type UART = BufferedUarte<'static, UARTE0, TIMER0>;
-type ENABLE = Output<'static, P0_03>;
-type RESET = Output<'static, P0_02>;
+type ENABLE = Output<'static, P0_09>;
+type RESET = Output<'static, P0_10>;
 
 pub struct MyDevice {
     wifi: Esp8266Wifi<UART, ENABLE, RESET>,
@@ -89,8 +89,8 @@ async fn main(spawner: embassy::executor::Spawner, p: Peripherals) {
         )
     };
 
-    let enable_pin = Output::new(p.P0_03, Level::Low, OutputDrive::Standard);
-    let reset_pin = Output::new(p.P0_02, Level::Low, OutputDrive::Standard);
+    let enable_pin = Output::new(p.P0_09, Level::Low, OutputDrive::Standard);
+    let reset_pin = Output::new(p.P0_10, Level::Low, OutputDrive::Standard);
 
     DEVICE.configure(MyDevice {
         wifi: Esp8266Wifi::new(u, enable_pin, reset_pin),

--- a/examples/stm32l0xx/lora-discovery/src/app.rs
+++ b/examples/stm32l0xx/lora-discovery/src/app.rs
@@ -162,8 +162,6 @@ where
     #[rustfmt::skip]
     type Message<'m> where D: 'm = Command;
     #[rustfmt::skip]
-    type Response<'m> where D: 'm = ();
-    #[rustfmt::skip]
     type OnStartFuture<'m> where D: 'm = impl Future<Output = ()> + 'm;
     #[rustfmt::skip]
     type OnMessageFuture<'m> where D: 'm = impl Future<Output = ()> + 'm;

--- a/examples/stm32l0xx/lora-discovery/src/lora.rs
+++ b/examples/stm32l0xx/lora-discovery/src/lora.rs
@@ -42,11 +42,11 @@ where
     #[rustfmt::skip]
     type Message<'m> where D: 'm = LoraCommand<'m>;
     #[rustfmt::skip]
-    type Response<'m> where D: 'm = LoraResult;
+    type Response = LoraResult;
     #[rustfmt::skip]
     type OnStartFuture<'m> where D: 'm = impl Future<Output = ()> + 'm;
     #[rustfmt::skip]
-    type OnMessageFuture<'m> where D: 'm = impl Future<Output = Self::Response<'m>> + 'm;
+    type OnMessageFuture<'m> where D: 'm = impl Future<Output = Self::Response> + 'm;
 
     fn on_start<'m>(self: Pin<&'m mut Self>) -> Self::OnStartFuture<'m> {
         async move {}


### PR DESCRIPTION
* Add generic WiFi actor abstraction that works with any driver
implementing the WifiSupplicant and TcpStack traits
* Add types for WifiAdapter and Socket to simplify usage of actor
* Migrate examples to use actor version