### PR TITLE
TLS support

### DIFF
--- a/device/Cargo.toml
+++ b/device/Cargo.toml
@@ -25,6 +25,10 @@ bit_field = { version = "0.10", optional = true }
 nom = { version = "6.1.2", default-features = false, optional = true }
 moveslice = { version = "2.0", optional = true }
 
+# TLS dependency
+drogue-tls = {git = "https://github.com/drogue-iot/drogue-tls.git", branch = "main", default-features = false, optional = true}
+rand_core = { version = "0.6.2", default-features = false, optional = true }
+
 # Utilities
 futures = { version = "0.3", default-features = false }
 heapless = "0.6"
@@ -55,6 +59,7 @@ std = ["embassy/std"]
 lora = []
 wifi = []
 fonts = []
+tls = ["drogue-tls", "rand_core"]
 
 defmt-default = [ ]
 defmt-trace = [ ]

--- a/device/src/actors/mod.rs
+++ b/device/src/actors/mod.rs
@@ -1,6 +1,7 @@
 pub mod button;
 pub mod led;
 pub mod lora;
+pub mod socket;
 pub mod ticker;
 pub mod timer;
 pub mod wifi;

--- a/device/src/actors/socket.rs
+++ b/device/src/actors/socket.rs
@@ -1,0 +1,244 @@
+use super::wifi::*;
+use crate::{
+    kernel::actor::Address,
+    traits::{
+        ip::{IpProtocol, SocketAddress},
+        tcp::{TcpError, TcpSocket, TcpStack},
+    },
+};
+
+use core::future::Future;
+
+/// A Socket type for connecting to a network endpoint + sending and receiving data.
+#[derive(Clone, Copy)]
+pub struct Socket<'a, A>
+where
+    A: Adapter + 'static,
+{
+    address: Address<'a, AdapterActor<A>>,
+    handle: A::SocketHandle,
+}
+
+impl<'a, A> Socket<'a, A>
+where
+    A: Adapter + 'static,
+{
+    pub fn new(address: Address<'a, AdapterActor<A>>, handle: A::SocketHandle) -> Socket<'a, A> {
+        Self { address, handle }
+    }
+}
+
+impl<'a, A> TcpSocket for Socket<'a, A>
+where
+    A: Adapter + 'static,
+{
+    #[rustfmt::skip]
+    type ConnectFuture<'m> where 'a: 'm, A: 'm =  impl Future<Output = Result<(), TcpError>>;
+    fn connect<'m>(&'m mut self, proto: IpProtocol, dst: SocketAddress) -> Self::ConnectFuture<'m> {
+        async move { self.address.connect(self.handle, proto, dst).await }
+    }
+
+    #[rustfmt::skip]
+    type WriteFuture<'m> where 'a: 'm, A: 'm = impl Future<Output = Result<usize, TcpError>>;
+    fn write<'m>(&'m mut self, buf: &'m [u8]) -> Self::WriteFuture<'m> {
+        async move { self.address.write(self.handle, buf).await }
+    }
+
+    #[rustfmt::skip]
+    type ReadFuture<'m> where 'a: 'm, A: 'm = impl Future<Output = Result<usize, TcpError>>;
+    fn read<'m>(&'m mut self, buf: &'m mut [u8]) -> Self::ReadFuture<'m> {
+        async move { self.address.read(self.handle, buf).await }
+    }
+
+    #[rustfmt::skip]
+    type CloseFuture<'m> where 'a: 'm, A: 'm = impl Future<Output = ()>;
+    fn close<'m>(&'m mut self) -> Self::CloseFuture<'m> {
+        async move { self.address.close(self.handle).await }
+    }
+}
+
+#[cfg(feature = "tls")]
+mod tls {
+    use super::{Adapter, Socket};
+    use crate::traits::{
+        ip::{IpProtocol, SocketAddress},
+        tcp::{TcpError, TcpSocket},
+    };
+    use core::future::Future;
+    use drogue_tls::{AsyncRead, AsyncWrite, Config, TlsCipherSuite, TlsConnection, TlsError};
+    use rand_core::{CryptoRng, RngCore};
+
+    impl<'a, T> AsyncRead for Socket<'a, T>
+    where
+        T: Adapter + 'static,
+    {
+        #[rustfmt::skip]
+        type ReadFuture<'m> where Self: 'm = impl Future<Output = Result<usize, TlsError>> + 'm;
+        fn read<'m>(&'m mut self, buf: &'m mut [u8]) -> Self::ReadFuture<'m> {
+            async move {
+                Ok(TcpSocket::read(self, buf)
+                    .await
+                    .map_err(|_| TlsError::IoError)?)
+            }
+        }
+    }
+
+    impl<'a, T> AsyncWrite for Socket<'a, T>
+    where
+        T: Adapter + 'static,
+    {
+        #[rustfmt::skip]
+        type WriteFuture<'m> where Self: 'm = impl Future<Output = Result<usize, TlsError>> + 'm;
+        fn write<'m>(&'m mut self, buf: &'m [u8]) -> Self::WriteFuture<'m> {
+            async move {
+                Ok(TcpSocket::write(self, buf)
+                    .await
+                    .map_err(|_| TlsError::IoError)?)
+            }
+        }
+    }
+
+    enum State<'a, S, RNG, CipherSuite, const FRAME_BUF_LEN: usize>
+    where
+        S: TcpSocket + AsyncWrite + AsyncRead + 'static,
+        RNG: CryptoRng + RngCore + Copy + 'static,
+        CipherSuite: TlsCipherSuite + 'static,
+    {
+        New(S),
+        Connected(TlsConnection<'a, RNG, S, CipherSuite, FRAME_BUF_LEN>),
+    }
+
+    pub struct TlsSocket<'a, S, RNG, CipherSuite, const FRAME_BUF_LEN: usize>
+    where
+        S: TcpSocket + AsyncWrite + AsyncRead + 'static,
+        RNG: CryptoRng + RngCore + Copy + 'static,
+        CipherSuite: TlsCipherSuite + 'static,
+    {
+        config: &'a Config<'a, RNG, CipherSuite>,
+        state: Option<State<'a, S, RNG, CipherSuite, FRAME_BUF_LEN>>,
+    }
+
+    impl<'a, S, RNG, CipherSuite, const FRAME_BUF_LEN: usize>
+        TlsSocket<'a, S, RNG, CipherSuite, FRAME_BUF_LEN>
+    where
+        S: TcpSocket + AsyncWrite + AsyncRead + 'static,
+        RNG: CryptoRng + RngCore + Copy + 'static,
+        CipherSuite: TlsCipherSuite + 'static,
+    {
+        pub fn wrap(socket: S, config: &'a Config<'a, RNG, CipherSuite>) -> Self {
+            Self {
+                config,
+                state: Some(State::New(socket)),
+            }
+        }
+    }
+
+    impl<'a, S, RNG, CipherSuite, const FRAME_BUF_LEN: usize> TcpSocket
+        for TlsSocket<'a, S, RNG, CipherSuite, FRAME_BUF_LEN>
+    where
+        S: TcpSocket + AsyncWrite + AsyncRead + 'static,
+        RNG: CryptoRng + RngCore + Copy + 'static,
+        CipherSuite: TlsCipherSuite + 'static,
+    {
+        #[rustfmt::skip]
+        type ConnectFuture<'m> where 'a: 'm, S: 'm, RNG: 'm, CipherSuite: 'm =  impl Future<Output = Result<(), TcpError>>;
+        fn connect<'m>(
+            &'m mut self,
+            proto: IpProtocol,
+            dst: SocketAddress,
+        ) -> Self::ConnectFuture<'m> {
+            async move {
+                match self.state.take() {
+                    Some(State::New(mut socket)) => match socket.connect(proto, dst).await {
+                        Ok(_) => {
+                            trace!("TCP connection opened");
+                            let mut tls: TlsConnection<'a, RNG, S, CipherSuite, FRAME_BUF_LEN> =
+                                TlsConnection::new(self.config, socket);
+                            match tls.open().await {
+                                Ok(_) => {
+                                    trace!("TLS connection opened");
+                                    self.state.replace(State::Connected(tls));
+                                    Ok(())
+                                }
+                                Err(e) => {
+                                    trace!("TLS connection failed: {:?}", e);
+                                    self.state.replace(State::New(tls.free()));
+                                    Err(TcpError::ConnectError)
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            trace!("TCP connection failed: {:?}", e);
+                            self.state.replace(State::New(socket));
+                            Err(e)
+                        }
+                    },
+                    Some(other) => {
+                        self.state.replace(other);
+                        Err(TcpError::ConnectError)
+                    }
+                    None => Err(TcpError::SocketClosed),
+                }
+            }
+        }
+
+        #[rustfmt::skip]
+        type WriteFuture<'m> where 'a: 'm, RNG: 'm, CipherSuite: 'm = impl Future<Output = Result<usize, TcpError>>;
+        fn write<'m>(&'m mut self, buf: &'m [u8]) -> Self::WriteFuture<'m> {
+            async move {
+                match self.state.take() {
+                    Some(State::Connected(mut session)) => {
+                        let result = session.write(buf).await.map_err(|_| TcpError::WriteError);
+                        self.state.replace(State::Connected(session));
+                        result
+                    }
+                    Some(other) => {
+                        self.state.replace(other);
+                        Err(TcpError::SocketClosed)
+                    }
+                    None => Err(TcpError::SocketClosed),
+                }
+            }
+        }
+
+        #[rustfmt::skip]
+        type ReadFuture<'m> where 'a: 'm, RNG: 'm, CipherSuite: 'm = impl Future<Output = Result<usize, TcpError>>;
+        fn read<'m>(&'m mut self, buf: &'m mut [u8]) -> Self::ReadFuture<'m> {
+            async move {
+                match self.state.take() {
+                    Some(State::Connected(mut session)) => {
+                        let result = session.read(buf).await.map_err(|_| TcpError::ReadError);
+                        self.state.replace(State::Connected(session));
+                        result
+                    }
+                    Some(other) => {
+                        self.state.replace(other);
+                        Err(TcpError::SocketClosed)
+                    }
+                    None => Err(TcpError::SocketClosed),
+                }
+            }
+        }
+
+        #[rustfmt::skip]
+        type CloseFuture<'m> where 'a: 'm, RNG: 'm, CipherSuite: 'm = impl Future<Output = ()>;
+        fn close<'m>(&'m mut self) -> Self::CloseFuture<'m> {
+            async move {
+                match self.state.take() {
+                    Some(State::Connected(session)) => {
+                        // TODO: Send TLS alert
+                        let mut socket = session.free();
+                        socket.close().await;
+                    }
+                    Some(State::New(mut socket)) => {
+                        socket.close().await;
+                    }
+                    None => {}
+                }
+            }
+        }
+    }
+}
+
+#[cfg(feature = "tls")]
+pub use tls::*;

--- a/device/src/actors/socket.rs
+++ b/device/src/actors/socket.rs
@@ -65,7 +65,7 @@ mod tls {
         tcp::{TcpError, TcpSocket},
     };
     use core::future::Future;
-    use drogue_tls::{AsyncRead, AsyncWrite, Config, TlsCipherSuite, TlsConnection, TlsError};
+    use drogue_tls::{AsyncRead, AsyncWrite, TlsCipherSuite, TlsConfig, TlsConnection, TlsError};
     use rand_core::{CryptoRng, RngCore};
 
     impl<'a, T> AsyncRead for Socket<'a, T>
@@ -114,7 +114,7 @@ mod tls {
         RNG: CryptoRng + RngCore + Copy + 'static,
         CipherSuite: TlsCipherSuite + 'static,
     {
-        config: &'a Config<'a, RNG, CipherSuite>,
+        config: &'a TlsConfig<'a, RNG, CipherSuite>,
         state: Option<State<'a, S, RNG, CipherSuite, FRAME_BUF_LEN>>,
     }
 
@@ -125,7 +125,7 @@ mod tls {
         RNG: CryptoRng + RngCore + Copy + 'static,
         CipherSuite: TlsCipherSuite + 'static,
     {
-        pub fn wrap(socket: S, config: &'a Config<'a, RNG, CipherSuite>) -> Self {
+        pub fn wrap(socket: S, config: &'a TlsConfig<'a, RNG, CipherSuite>) -> Self {
             Self {
                 config,
                 state: Some(State::New(socket)),

--- a/device/src/testutil.rs
+++ b/device/src/testutil.rs
@@ -65,8 +65,11 @@ impl<D> TestContext<D> {
     }
 
     /// Mount the device, running the provided callback function.
-    pub fn mount<F: FnOnce(&'static D) -> R, R>(&mut self, f: F) -> R {
-        self.device.mount(f)
+    pub async fn mount<FUT: Future<Output = R>, F: FnOnce(&'static D) -> FUT, R>(
+        &mut self,
+        f: F,
+    ) -> R {
+        self.device.mount(f).await
     }
 }
 

--- a/device/src/traits/tcp.rs
+++ b/device/src/traits/tcp.rs
@@ -1,13 +1,36 @@
 use super::ip::{IpProtocol, SocketAddress};
 use core::future::Future;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum TcpError {
     ConnectError,
     ReadError,
     WriteError,
     CloseError,
+    IoError,
     SocketClosed,
+}
+
+pub trait TcpSocket {
+    type ConnectFuture<'m>: Future<Output = Result<(), TcpError>>
+    where
+        Self: 'm;
+    fn connect<'m>(&'m mut self, proto: IpProtocol, dst: SocketAddress) -> Self::ConnectFuture<'m>;
+
+    type WriteFuture<'m>: Future<Output = Result<usize, TcpError>>
+    where
+        Self: 'm;
+    fn write<'m>(&'m mut self, buf: &'m [u8]) -> Self::WriteFuture<'m>;
+
+    type ReadFuture<'m>: Future<Output = Result<usize, TcpError>>
+    where
+        Self: 'm;
+    fn read<'m>(&'m mut self, buf: &'m mut [u8]) -> Self::ReadFuture<'m>;
+
+    type CloseFuture<'m>: Future<Output = ()>
+    where
+        Self: 'm;
+    fn close<'m>(&'m mut self) -> Self::CloseFuture<'m>;
 }
 
 pub trait TcpStack {

--- a/device/tests/button_tests.rs
+++ b/device/tests/button_tests.rs
@@ -26,10 +26,12 @@ mod tests {
             button: ActorContext::new(Button::new(pin)),
         });
 
-        context.mount(|device| {
-            let handler_addr = device.handler.mount((), spawner);
-            device.button.mount(handler_addr, spawner);
-        });
+        context
+            .mount(|device| async move {
+                let handler_addr = device.handler.mount((), spawner);
+                device.button.mount(handler_addr, spawner);
+            })
+            .await;
 
         assert!(notified.message().is_none());
         pin.set_low();
@@ -52,10 +54,12 @@ mod tests {
             button: ActorContext::new(Button::new(pin)),
         });
 
-        context.mount(|device| {
-            let handler_addr = device.handler.mount((), spawner);
-            device.button.mount(handler_addr, spawner);
-        });
+        context
+            .mount(|device| async move {
+                let handler_addr = device.handler.mount((), spawner);
+                device.button.mount(handler_addr, spawner);
+            })
+            .await;
 
         assert!(notified.message().is_none());
         pin.set_high();

--- a/device/tests/integration_tests.rs
+++ b/device/tests/integration_tests.rs
@@ -54,7 +54,9 @@ mod tests {
                 }),
             });
 
-            let a_addr = DEVICE.mount(|device| device.a.mount((), spawner));
+            let a_addr = DEVICE
+                .mount(|device| async move { device.a.mount((), spawner) })
+                .await;
 
             a_addr.request(Add(10)).unwrap().await;
         }

--- a/device/tests/ticker_tests.rs
+++ b/device/tests/ticker_tests.rs
@@ -26,10 +26,12 @@ mod tests {
             ticker: ActorContext::new(Ticker::new(Duration::from_secs(1), TestMessage(1))),
         });
 
-        context.mount(|device| {
-            let handler_addr = device.handler.mount((), spawner);
-            (device.ticker.mount(handler_addr, spawner), handler_addr)
-        });
+        context
+            .mount(|device| async move {
+                let handler_addr = device.handler.mount((), spawner);
+                (device.ticker.mount(handler_addr, spawner), handler_addr)
+            })
+            .await;
 
         notified.wait_signaled().await;
         assert_eq!(1, notified.message().unwrap().0);

--- a/device/tests/timer_tests.rs
+++ b/device/tests/timer_tests.rs
@@ -26,10 +26,12 @@ mod tests {
             timer: ActorContext::new(Timer::new()),
         });
 
-        let (timer_addr, handler_addr) = context.mount(|device| {
-            let handler_addr = device.handler.mount((), spawner);
-            (device.timer.mount((), spawner), handler_addr)
-        });
+        let (timer_addr, handler_addr) = context
+            .mount(|device| async move {
+                let handler_addr = device.handler.mount((), spawner);
+                (device.timer.mount((), spawner), handler_addr)
+            })
+            .await;
 
         let before = time::Instant::now();
         timer_addr
@@ -55,7 +57,9 @@ mod tests {
             timer: ActorContext::new(Timer::new()),
         });
 
-        let timer = context.mount(|device| device.timer.mount((), spawner));
+        let timer = context
+            .mount(|device| async move { device.timer.mount((), spawner) })
+            .await;
 
         let before = time::Instant::now();
         timer

--- a/examples/common/wifi/Cargo.lock
+++ b/examples/common/wifi/Cargo.lock
@@ -45,6 +45,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fe8f5a8a398345e52358e18ff07cc17a568fbca5c6f73873d3a62056309603"
 
 [[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
 name = "bitfield"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -74,7 +80,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "cortex-m"
 version = "0.7.2"
-source = "git+https://github.com/rust-embedded/cortex-m.git?branch=master#1a4e09646aa37c3408d69fe4452265f405400593"
+source = "git+https://github.com/rust-embedded/cortex-m.git?branch=master#47246ecc06f7a6665885fd19cd14f35fa390ab95"
 dependencies = [
  "bare-metal 0.2.5",
  "bitfield",
@@ -354,9 +360,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
 name = "pin-utils"
@@ -472,6 +478,7 @@ dependencies = [
 name = "wifi-app"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "drogue-device",
  "heapless",
  "log",

--- a/examples/common/wifi/Cargo.toml
+++ b/examples/common/wifi/Cargo.toml
@@ -10,9 +10,10 @@ version = "0.1.0"
 [workspace]
 
 [dependencies]
-drogue-device = { path = "../../../device", features = ["wifi"], default-features = false }
+drogue-device = { path = "../../../device", default-features = false }
 log = "0.4"
 heapless = "0.6"
+base64 = { version = "0.13.0", default-features = false }
 
 [patch.crates-io]
 cortex-m = {git = "https://github.com/rust-embedded/cortex-m.git", branch = "master", features = ["device"]}

--- a/examples/common/wifi/src/http.rs
+++ b/examples/common/wifi/src/http.rs
@@ -1,0 +1,100 @@
+use core::fmt::Write;
+use drogue_device::traits::{
+    ip::{IpAddress, IpProtocol, SocketAddress},
+    tcp::TcpSocket,
+};
+use heapless::{consts, String};
+
+pub struct HttpClient<'a, S>
+where
+    S: TcpSocket + 'static,
+{
+    socket: &'a mut S,
+    ip: IpAddress,
+    port: u16,
+    username: &'a str,
+    password: &'a str,
+}
+
+impl<'a, S> HttpClient<'a, S>
+where
+    S: TcpSocket + 'static,
+{
+    pub fn new(
+        socket: &'a mut S,
+        ip: IpAddress,
+        port: u16,
+        username: &'a str,
+        password: &'a str,
+    ) -> Self {
+        Self {
+            socket,
+            ip,
+            port,
+            username,
+            password,
+        }
+    }
+
+    pub async fn post(
+        &mut self,
+        path: &str,
+        payload: &[u8],
+        content_type: &str,
+        rx_buf: &mut [u8],
+    ) -> Result<usize, ()> {
+        match self
+            .socket
+            .connect(IpProtocol::Tcp, SocketAddress::new(self.ip, self.port))
+            .await
+        {
+            Ok(_) => {
+                log::info!("Connected to {}:{}", self.ip, self.port);
+                let mut combined: String<consts::U128> = String::new();
+                write!(combined, "{}:{}", self.username, self.password).unwrap();
+                let mut authz = [0; 256];
+                let authz_len =
+                    base64::encode_config_slice(combined.as_bytes(), base64::STANDARD, &mut authz);
+                let mut request: String<consts::U1024> = String::new();
+                write!(request, "POST {} HTTP/1.1\r\n", path).unwrap();
+                write!(request, "Authorization: Basic {}\r\n", unsafe {
+                    core::str::from_utf8_unchecked(&authz[..authz_len])
+                })
+                .unwrap();
+                write!(request, "Content-Type: {}\r\n", content_type).unwrap();
+                write!(request, "Content-Length: {}\r\n\r\n", payload.len()).unwrap();
+                let result = self
+                    .socket
+                    .write(&request.as_bytes()[..request.len()])
+                    .await;
+                match result {
+                    Ok(_) => {
+                        let result = self.socket.write(payload).await;
+                        match result {
+                            Ok(_) => {
+                                log::info!("Request sent");
+                                let response = self
+                                    .socket
+                                    .read(&mut rx_buf[..])
+                                    .await
+                                    .expect("error reading response");
+                                log::info!("Got {} bytes in response", response);
+                                return Ok(response);
+                            }
+                            Err(e) => {
+                                log::warn!("Error sending data: {:?}", e);
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        log::warn!("Error sending headers: {:?}", e);
+                    }
+                }
+            }
+            Err(e) => {
+                log::info!("Error connecting to {}:{}: {:?}", self.ip, self.port, e);
+            }
+        }
+        Err(())
+    }
+}

--- a/examples/common/wifi/src/lib.rs
+++ b/examples/common/wifi/src/lib.rs
@@ -15,7 +15,7 @@ use core::pin::Pin;
 use drogue_device::{
     actors::button::{ButtonEvent, FromButtonEvent},
     traits::{ip::*, tcp::*},
-    Actor,
+    Actor, Address,
 };
 pub enum Command {
     Send,

--- a/examples/nrf52/microbit-esp8266/Cargo.lock
+++ b/examples/nrf52/microbit-esp8266/Cargo.lock
@@ -54,6 +54,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fe8f5a8a398345e52358e18ff07cc17a568fbca5c6f73873d3a62056309603"
 
 [[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
 name = "bitfield"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,7 +102,7 @@ dependencies = [
 [[package]]
 name = "cortex-m"
 version = "0.7.2"
-source = "git+https://github.com/rust-embedded/cortex-m.git?branch=master#1a4e09646aa37c3408d69fe4452265f405400593"
+source = "git+https://github.com/rust-embedded/cortex-m.git?branch=master#47246ecc06f7a6665885fd19cd14f35fa390ab95"
 dependencies = [
  "bare-metal 0.2.5",
  "bitfield",
@@ -401,9 +407,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.4.0"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "microbit-esp8266"
@@ -445,9 +451,9 @@ checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
 
 [[package]]
 name = "nom"
-version = "6.1.2"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
+checksum = "9c5c51b9083a3c620fa67a2a635d1ce7d95b897e957d6b28ff9a5da960a103a6"
 dependencies = [
  "memchr",
  "version_check",
@@ -498,9 +504,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
 name = "pin-utils"
@@ -654,6 +660,7 @@ dependencies = [
 name = "wifi-app"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "drogue-device",
  "heapless",
  "log",

--- a/examples/nrf52/microbit-esp8266/build.rs
+++ b/examples/nrf52/microbit-esp8266/build.rs
@@ -36,6 +36,8 @@ fn main() {
     fs::create_dir_all(out.join("config")).expect("error creating output directory for config");
     copy_config(&out, "config/wifi.ssid.txt");
     copy_config(&out, "config/wifi.password.txt");
+    copy_config(&out, "config/drogue.username.txt");
+    copy_config(&out, "config/drogue.password.txt");
 
     // By default, Cargo will re-run a build script whenever
     // any file in the project changes. By specifying `memory.x`

--- a/examples/nrf52/microbit-rak811/Cargo.lock
+++ b/examples/nrf52/microbit-rak811/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
 [[package]]
 name = "cortex-m"
 version = "0.7.2"
-source = "git+https://github.com/rust-embedded/cortex-m.git?branch=master#1a4e09646aa37c3408d69fe4452265f405400593"
+source = "git+https://github.com/rust-embedded/cortex-m.git?branch=master#47246ecc06f7a6665885fd19cd14f35fa390ab95"
 dependencies = [
  "bare-metal 0.2.5",
  "bitfield",
@@ -401,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.4.0"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "microbit-rak811"
@@ -443,9 +443,9 @@ checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
 
 [[package]]
 name = "nom"
-version = "6.1.2"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
+checksum = "9c5c51b9083a3c620fa67a2a635d1ce7d95b897e957d6b28ff9a5da960a103a6"
 dependencies = [
  "memchr",
  "version_check",
@@ -496,9 +496,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
 name = "pin-utils"

--- a/examples/nrf52/microbit-rak811/src/main.rs
+++ b/examples/nrf52/microbit-rak811/src/main.rs
@@ -100,10 +100,12 @@ async fn main(spawner: embassy::executor::Spawner, p: Peripherals) {
         button: ActorContext::new(Button::new(button_port)),
     });
 
-    DEVICE.mount(|device| {
-        let (controller, modem) = unsafe { &mut *device.driver.get() }.initialize(u, reset_pin);
-        device.modem.mount(modem, spawner);
-        let app = device.app.mount(controller, spawner);
-        device.button.mount(app, spawner);
-    });
+    DEVICE
+        .mount(|device| async move {
+            let (controller, modem) = unsafe { &mut *device.driver.get() }.initialize(u, reset_pin);
+            device.modem.mount(modem, spawner);
+            let app = device.app.mount(controller, spawner);
+            device.button.mount(app, spawner);
+        })
+        .await;
 }

--- a/examples/nrf52/microbit-uart/Cargo.lock
+++ b/examples/nrf52/microbit-uart/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
 [[package]]
 name = "cortex-m"
 version = "0.7.2"
-source = "git+https://github.com/rust-embedded/cortex-m.git?branch=master#1a4e09646aa37c3408d69fe4452265f405400593"
+source = "git+https://github.com/rust-embedded/cortex-m.git?branch=master#47246ecc06f7a6665885fd19cd14f35fa390ab95"
 dependencies = [
  "bare-metal 0.2.5",
  "bitfield",
@@ -173,19 +173,19 @@ dependencies = [
 
 [[package]]
 name = "defmt"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aba21ce228b4769b8b5b6d2e2ee28c5dcfbe60c46f76b63d88b3a6677c8dc5b"
+checksum = "15fe96f5d208164afa70583ff8f062e7697cbbb0b98e5076fbf8ac6da9edff0f"
 dependencies = [
  "defmt-macros",
- "semver 0.11.0",
+ "semver 1.0.3",
 ]
 
 [[package]]
 name = "defmt-macros"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b101f3d11ecbbd6046cabd76e2c5b6b20eb493de5a83fea4c0704864b886dfd6"
+checksum = "9bd2c3949cb76c25f48c363e61b97f05b317efe3c12fa45d54a6599c3949c85e"
 dependencies = [
  "defmt-parser",
  "proc-macro2",
@@ -195,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "defmt-parser"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc63e313e87db4666440753288012024f117065b52e9b9f4d0d869e9fada6404"
+checksum = "bc621c2b4f5f5635e34021c38af2ccb0c1dae38ba11ebee25258de8bb1cee9fe"
 
 [[package]]
 name = "defmt-rtt"
@@ -479,15 +479,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pest"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
-dependencies = [
- "ucd-trie",
-]
-
-[[package]]
 name = "pin-project"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,9 +500,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
 name = "pin-utils"
@@ -558,32 +549,20 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser 0.7.0",
+ "semver-parser",
 ]
 
 [[package]]
 name = "semver"
-version = "0.11.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser 0.10.2",
-]
+checksum = "5f3aac57ee7f3272d8395c6e4f502f434f0e289fcd62876f70daa008c20dcabe"
 
 [[package]]
 name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
 
 [[package]]
 name = "stable_deref_trait"
@@ -613,12 +592,6 @@ name = "typenum"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-xid"

--- a/examples/nrf52/microbit-uart/src/main.rs
+++ b/examples/nrf52/microbit-uart/src/main.rs
@@ -91,12 +91,14 @@ async fn main(spawner: embassy::executor::Spawner, p: Peripherals) {
         matrix: ActorContext::new(led),
     });
 
-    DEVICE.mount(|device| {
-        let matrix = device.matrix.mount((), spawner);
-        let statistics = device.statistics.mount((), spawner);
-        device.server.mount((matrix, statistics), spawner);
-        device.button.mount(statistics, spawner);
-        let ticker = device.ticker.mount(matrix, spawner);
-        ticker.notify(TickerCommand::Start).unwrap();
-    });
+    DEVICE
+        .mount(|device| async move {
+            let matrix = device.matrix.mount((), spawner);
+            let statistics = device.statistics.mount((), spawner);
+            device.server.mount((matrix, statistics), spawner);
+            device.button.mount(statistics, spawner);
+            let ticker = device.ticker.mount(matrix, spawner);
+            ticker.notify(TickerCommand::Start).unwrap();
+        })
+        .await;
 }

--- a/examples/rp/blinky/Cargo.lock
+++ b/examples/rp/blinky/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
 [[package]]
 name = "cortex-m"
 version = "0.7.2"
-source = "git+https://github.com/rust-embedded/cortex-m.git?branch=master#1a4e09646aa37c3408d69fe4452265f405400593"
+source = "git+https://github.com/rust-embedded/cortex-m.git?branch=master#47246ecc06f7a6665885fd19cd14f35fa390ab95"
 dependencies = [
  "bare-metal 0.2.5",
  "bitfield",
@@ -190,19 +190,19 @@ dependencies = [
 
 [[package]]
 name = "defmt"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aba21ce228b4769b8b5b6d2e2ee28c5dcfbe60c46f76b63d88b3a6677c8dc5b"
+checksum = "15fe96f5d208164afa70583ff8f062e7697cbbb0b98e5076fbf8ac6da9edff0f"
 dependencies = [
  "defmt-macros",
- "semver 0.11.0",
+ "semver 1.0.3",
 ]
 
 [[package]]
 name = "defmt-macros"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b101f3d11ecbbd6046cabd76e2c5b6b20eb493de5a83fea4c0704864b886dfd6"
+checksum = "9bd2c3949cb76c25f48c363e61b97f05b317efe3c12fa45d54a6599c3949c85e"
 dependencies = [
  "defmt-parser",
  "proc-macro2",
@@ -212,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "defmt-parser"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc63e313e87db4666440753288012024f117065b52e9b9f4d0d869e9fada6404"
+checksum = "bc621c2b4f5f5635e34021c38af2ccb0c1dae38ba11ebee25258de8bb1cee9fe"
 
 [[package]]
 name = "defmt-rtt"
@@ -459,15 +459,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pest"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
-dependencies = [
- "ucd-trie",
-]
-
-[[package]]
 name = "pin-project"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -489,9 +480,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
 name = "pin-utils"
@@ -547,32 +538,20 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 dependencies = [
- "semver-parser 0.7.0",
+ "semver-parser",
 ]
 
 [[package]]
 name = "semver"
-version = "0.11.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
-dependencies = [
- "semver-parser 0.10.2",
-]
+checksum = "5f3aac57ee7f3272d8395c6e4f502f434f0e289fcd62876f70daa008c20dcabe"
 
 [[package]]
 name = "semver-parser"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
-
-[[package]]
-name = "semver-parser"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
-dependencies = [
- "pest",
-]
 
 [[package]]
 name = "stable_deref_trait"
@@ -602,12 +581,6 @@ name = "typenum"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-xid"

--- a/examples/rp/blinky/src/main.rs
+++ b/examples/rp/blinky/src/main.rs
@@ -30,7 +30,9 @@ async fn main(spawner: embassy::executor::Spawner, p: Peripherals) {
         led: ActorContext::new(Led::new(Output::new(p.PIN_25, Level::Low))),
     });
 
-    let led = DEVICE.mount(|device| device.led.mount((), spawner));
+    let led = DEVICE
+        .mount(|device| async move { device.led.mount((), spawner) })
+        .await;
 
     loop {
         cortex_m::asm::delay(1_000_000);

--- a/examples/std/esp8266/Cargo.lock
+++ b/examples/std/esp8266/Cargo.lock
@@ -349,7 +349,7 @@ dependencies = [
 [[package]]
 name = "drogue-tls"
 version = "0.2.0"
-source = "git+https://github.com/drogue-iot/drogue-tls.git?branch=main#170b99fa5590c04e9b32a79b9fd6461cdcd4e87f"
+source = "git+https://github.com/drogue-iot/drogue-tls.git?branch=main#f418585bf5d2cf8dad9b2d39745e1d9c45dd4dde"
 dependencies = [
  "aes-gcm",
  "digest",

--- a/examples/std/esp8266/Cargo.lock
+++ b/examples/std/esp8266/Cargo.lock
@@ -3,10 +3,64 @@
 version = 3
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.18"
+name = "aead"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "7fc95d1bdb8e6666b2b217308eeeb09f2d6728d104be3e31916cc74d15420331"
+dependencies = [
+ "generic-array 0.14.4",
+]
+
+[[package]]
+name = "aes"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884391ef1066acaa41e766ba8f596341b96e93ce34f9a43e7d24bf0a0eaf0561"
+dependencies = [
+ "aes-soft",
+ "aesni",
+ "cipher",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5278b5fabbb9bd46e24aa69b2fdea62c99088e0a950a9be40e3e0101298f88da"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
+name = "aes-soft"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be14c7498ea50828a38d0e24a765ed2effe92a705885b57d029cd67d45744072"
+dependencies = [
+ "cipher",
+ "opaque-debug",
+]
+
+[[package]]
+name = "aesni"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2e11f5e94c2f7d386164cc2aa1f97823fed6f259e486940a71c174dd01b0ce"
+dependencies = [
+ "cipher",
+ "opaque-debug",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
 dependencies = [
  "memchr",
 ]
@@ -85,6 +139,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fe8f5a8a398345e52358e18ff07cc17a568fbca5c6f73873d3a62056309603"
 
 [[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
 name = "bitfield"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,6 +155,27 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "bitvec"
+version = "0.20.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array 0.14.4",
+]
 
 [[package]]
 name = "byteorder"
@@ -130,6 +211,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cipher"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
+dependencies = [
+ "generic-array 0.14.4",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,13 +231,28 @@ dependencies = [
 [[package]]
 name = "cortex-m"
 version = "0.7.2"
-source = "git+https://github.com/rust-embedded/cortex-m.git?branch=master#1a4e09646aa37c3408d69fe4452265f405400593"
+source = "git+https://github.com/rust-embedded/cortex-m.git?branch=master#47246ecc06f7a6665885fd19cd14f35fa390ab95"
 dependencies = [
  "bare-metal 0.2.5",
  "bitfield",
  "embedded-hal",
  "volatile-register",
 ]
+
+[[package]]
+name = "cpufeatures"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66c99696f6c9dd7f35d486b9d04d7e6e202aa3e8c40d553f2fdf5e7e0c6a71ef"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpuid-bool"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb25d077389e53838a8158c8e99174c5a9d902dee4904320db714f3c653ffba"
 
 [[package]]
 name = "critical-section"
@@ -158,6 +263,25 @@ dependencies = [
  "bare-metal 1.0.0",
  "cfg-if",
  "cortex-m",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4857fd85a0c34b3c3297875b747c1e02e06b6a0ea32dd892d8192b9ce0813ea6"
+dependencies = [
+ "generic-array 0.14.4",
+ "subtle",
+]
+
+[[package]]
+name = "ctr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb4a30d54f7443bf3d6191dcd486aca19e67cb3c49fa7a06a319966346707e7f"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -196,11 +320,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array 0.14.4",
+]
+
+[[package]]
 name = "drogue-device"
 version = "0.1.0"
 dependencies = [
  "atomic-polyfill",
  "critical-section",
+ "drogue-tls",
  "embassy",
  "embedded-hal",
  "futures",
@@ -209,6 +343,40 @@ dependencies = [
  "log",
  "moveslice",
  "nom",
+ "rand_core",
+]
+
+[[package]]
+name = "drogue-tls"
+version = "0.2.0"
+source = "git+https://github.com/drogue-iot/drogue-tls.git?branch=main#170b99fa5590c04e9b32a79b9fd6461cdcd4e87f"
+dependencies = [
+ "aes-gcm",
+ "digest",
+ "generic-array 0.14.4",
+ "heapless",
+ "hkdf",
+ "hmac",
+ "nom",
+ "p256",
+ "rand_core",
+ "sha2",
+ "typenum",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13e9b0c3c4170dcc2a12783746c4205d98e18957f57854251eea3f9750fe005"
+dependencies = [
+ "bitvec",
+ "ff",
+ "generic-array 0.14.4",
+ "group",
+ "rand_core",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -284,6 +452,7 @@ version = "0.1.0"
 dependencies = [
  "async-io",
  "drogue-device",
+ "drogue-tls",
  "embassy",
  "embassy-std",
  "embedded-hal",
@@ -291,6 +460,7 @@ dependencies = [
  "futures",
  "log",
  "nix",
+ "rand",
  "wifi-app",
 ]
 
@@ -304,10 +474,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72a4d941a5b7c2a75222e2d44fcdf634a67133d9db31e177ae5ff6ecda852bfe"
+dependencies = [
+ "bitvec",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "funty"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
@@ -435,6 +622,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "ghash"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97304e4cd182c3846f7575ced3890c53012ce534ad9114046b0a9e00bb30a375"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
+
+[[package]]
+name = "group"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61b3c1e8b4f1ca07e6605ea1be903a5f6956aec5c8a67fd44d56076631675ed8"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "hash32"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,11 +676,31 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51ab2f639c231793c5f6114bdb9bbe50a7dbbfcd7c7c6bd8475dec2d991e964f"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1441c6b1e930e2817404b5046f1f989899143a12bf92de603b69f4e0aee1e15"
+dependencies = [
+ "crypto-mac",
+ "digest",
 ]
 
 [[package]]
@@ -508,9 +747,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.4.0"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "moveslice"
@@ -547,9 +786,9 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "6.1.2"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7413f999671bd4745a7b624bd370a569fb6bc574b23c83a3c5ed2e453f3d5e2"
+checksum = "9c5c51b9083a3c620fa67a2a635d1ce7d95b897e957d6b28ff9a5da960a103a6"
 dependencies = [
  "memchr",
  "version_check",
@@ -560,6 +799,21 @@ name = "once_cell"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+
+[[package]]
+name = "p256"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f05f5287453297c4c16af5e2b04df8fd2a3008d70f252729650bc6d7ace5844"
+dependencies = [
+ "elliptic-curve",
+]
 
 [[package]]
 name = "parking"
@@ -589,9 +843,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
 name = "pin-utils"
@@ -611,6 +865,23 @@ dependencies = [
  "wepoll-ffi",
  "winapi",
 ]
+
+[[package]]
+name = "polyval"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc4aa140b9abd2bc40d9c3f7ccec842679cd79045ac3a7ac698c1a064b7cd"
+dependencies = [
+ "cpuid-bool",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "proc-macro-hack"
@@ -643,10 +914,56 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.5.4"
+name = "radium"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
+
+[[package]]
+name = "rand"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "regex"
+version = "1.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a26af418b574bd56588335b3a3659a65725d4e636eb1016c2f9e3b38c7cc759"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -684,6 +1001,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
+name = "sha2"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b362ae5752fd2137731f9fa25fd4d9058af34666ca1966fb969119cc35719f12"
+dependencies = [
+ "block-buffer",
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+ "opaque-debug",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -712,6 +1042,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
+name = "subtle"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
+
+[[package]]
 name = "syn"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,6 +1057,12 @@ dependencies = [
  "quote",
  "unicode-xid",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "termcolor"
@@ -742,6 +1084,16 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "universal-hash"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
+dependencies = [
+ "generic-array 0.14.4",
+ "subtle",
+]
 
 [[package]]
 name = "vcell"
@@ -777,6 +1129,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
 name = "wepoll-ffi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,6 +1147,7 @@ dependencies = [
 name = "wifi-app"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "drogue-device",
  "heapless",
  "log",
@@ -824,3 +1183,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+
+[[package]]
+name = "zeroize"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"

--- a/examples/std/esp8266/Cargo.toml
+++ b/examples/std/esp8266/Cargo.toml
@@ -12,9 +12,11 @@ version = "0.1.0"
 [dependencies]
 log = "0.4"
 env_logger = "0.8"
-drogue-device = { path = "../../../device", features = ["log", "std", "wifi+esp8266"] }
+drogue-device = { path = "../../../device", features = ["log", "std", "wifi+esp8266", "tls"] }
+drogue-tls = {git = "https://github.com/drogue-iot/drogue-tls.git", branch = "main", default-features = false}
 embassy = {git = "https://github.com/drogue-iot/embassy.git", branch = "master", features = ["std"] }
 embassy-std = {git = "https://github.com/drogue-iot/embassy.git", branch = "master", default-features = false }
+rand = "0.8"
 
 embedded-hal = {version = "0.2.4", features = ["unproven"] }
 wifi-app = { path = "../../common/wifi" }

--- a/examples/std/esp8266/build.rs
+++ b/examples/std/esp8266/build.rs
@@ -36,6 +36,8 @@ fn main() {
     fs::create_dir_all(out.join("config")).expect("error creating output directory for config");
     copy_config(&out, "config/wifi.ssid.txt");
     copy_config(&out, "config/wifi.password.txt");
+    copy_config(&out, "config/drogue.username.txt");
+    copy_config(&out, "config/drogue.password.txt");
 
     // By default, Cargo will re-run a build script whenever
     // any file in the project changes. By specifying `memory.x`

--- a/examples/std/esp8266/src/main.rs
+++ b/examples/std/esp8266/src/main.rs
@@ -15,7 +15,7 @@ use drogue_device::{
     traits::{ip::*, tcp::*, wifi::*},
     *,
 };
-use drogue_tls::{Aes128GcmSha256, Config as TlsConfig};
+use drogue_tls::{Aes128GcmSha256, TlsConfig};
 use embassy::{io::FromStdIo, time, util::Forever};
 use embedded_hal::digital::v2::OutputPin;
 use futures::io::BufReader;

--- a/examples/std/esp8266/src/main.rs
+++ b/examples/std/esp8266/src/main.rs
@@ -10,32 +10,42 @@ mod serial;
 
 use async_io::Async;
 use drogue_device::{
-    actors::wifi::{esp8266::*, *},
+    actors::{socket::*, wifi::esp8266::*},
     drivers::wifi::esp8266::*,
-    traits::ip::*,
+    traits::{ip::*, tcp::*, wifi::*},
     *,
 };
-use embassy::{io::FromStdIo, time};
+use drogue_tls::{Aes128GcmSha256, Config as TlsConfig};
+use embassy::{io::FromStdIo, time, util::Forever};
 use embedded_hal::digital::v2::OutputPin;
 use futures::io::BufReader;
 use nix::sys::termios;
+use rand::rngs::OsRng;
 use serial::*;
 use wifi_app::*;
 
 const WIFI_SSID: &str = include_str!(concat!(env!("OUT_DIR"), "/config/wifi.ssid.txt"));
 const WIFI_PSK: &str = include_str!(concat!(env!("OUT_DIR"), "/config/wifi.password.txt"));
-const HOST: IpAddress = IpAddress::new_v4(192, 168, 1, 2);
-const PORT: u16 = 12345;
+const HOST: &str = "http.sandbox.drogue.cloud";
+const USERNAME: &str = include_str!(concat!(env!("OUT_DIR"), "/config/drogue.username.txt"));
+const PASSWORD: &str = include_str!(concat!(env!("OUT_DIR"), "/config/drogue.password.txt"));
+
+const IP: IpAddress = IpAddress::new_v4(95, 216, 224, 167); // IP resolved for "http.sandbox.drogue.cloud"
+const PORT: u16 = 443;
 
 type UART = FromStdIo<BufReader<Async<SerialPort>>>;
 type ENABLE = DummyPin;
 type RESET = DummyPin;
+type AppSocket =
+    TlsSocket<'static, Socket<'static, Esp8266Controller<'static>>, OsRng, Aes128GcmSha256, 16384>;
 
 pub struct MyDevice {
     wifi: Esp8266Wifi<UART, ENABLE, RESET>,
-    app: ActorContext<'static, App<Esp8266Controller<'static>>>,
+    app: ActorContext<'static, App<AppSocket>>,
 }
 static DEVICE: DeviceContext<MyDevice> = DeviceContext::new();
+
+static TLS_CONFIG: Forever<TlsConfig<'static, OsRng, Aes128GcmSha256>> = Forever::new();
 
 #[embassy::main]
 async fn main(spawner: embassy::executor::Spawner) {
@@ -50,24 +60,33 @@ async fn main(spawner: embassy::executor::Spawner) {
     let port = BufReader::new(port);
     let port = FromStdIo::new(port);
 
+    let tls_config = TLS_CONFIG.put(TlsConfig::new(OsRng).with_server_name(HOST.trim_end()));
+
     DEVICE.configure(MyDevice {
         wifi: Esp8266Wifi::new(port, DummyPin {}, DummyPin {}),
-        app: ActorContext::new(App::new(
-            WIFI_SSID.trim_end(),
-            WIFI_PSK.trim_end(),
-            HOST,
-            PORT,
-        )),
+        app: ActorContext::new(App::new(IP, PORT, USERNAME.trim_end(), PASSWORD.trim_end())),
     });
 
-    let app = DEVICE.mount(|device| {
-        let wifi = device.wifi.mount((), spawner);
-        device.app.mount(WifiAdapter::new(wifi), spawner)
-    });
+    let app = DEVICE
+        .mount(|device| async move {
+            let mut wifi = device.wifi.mount((), spawner);
+            wifi.join(Join::Wpa {
+                ssid: WIFI_SSID.trim_end(),
+                password: WIFI_PSK.trim_end(),
+            })
+            .await
+            .expect("Error joining wifi");
+
+            let socket = Socket::new(wifi, wifi.open().await);
+            let tls_socket = TlsSocket::wrap(socket, tls_config);
+            device.app.mount(tls_socket, spawner)
+        })
+        .await;
 
     loop {
+        time::Timer::after(time::Duration::from_secs(20)).await;
         app.request(Command::Send).unwrap().await;
-        time::Timer::after(time::Duration::from_secs(10)).await;
+        break;
     }
 }
 

--- a/examples/std/hello/Cargo.lock
+++ b/examples/std/hello/Cargo.lock
@@ -94,7 +94,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "cortex-m"
 version = "0.7.2"
-source = "git+https://github.com/rust-embedded/cortex-m.git?branch=master#1a4e09646aa37c3408d69fe4452265f405400593"
+source = "git+https://github.com/rust-embedded/cortex-m.git?branch=master#47246ecc06f7a6665885fd19cd14f35fa390ab95"
 dependencies = [
  "bare-metal 0.2.5",
  "bitfield",
@@ -363,9 +363,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
@@ -446,9 +446,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
 name = "pin-utils"

--- a/examples/std/hello/src/main.rs
+++ b/examples/std/hello/src/main.rs
@@ -39,12 +39,14 @@ async fn main(spawner: embassy::executor::Spawner) {
         p: MyPack::new(),
     });
 
-    let (a_addr, b_addr, c_addr) = DEVICE.mount(|device| {
-        let a_addr = device.a.mount(&device.counter, spawner);
-        let b_addr = device.b.mount(&device.counter, spawner);
-        let c_addr = device.p.mount((), spawner);
-        (a_addr, b_addr, c_addr)
-    });
+    let (a_addr, b_addr, c_addr) = DEVICE
+        .mount(|device| async move {
+            let a_addr = device.a.mount(&device.counter, spawner);
+            let b_addr = device.b.mount(&device.counter, spawner);
+            let c_addr = device.p.mount((), spawner);
+            (a_addr, b_addr, c_addr)
+        })
+        .await;
 
     loop {
         time::Timer::after(time::Duration::from_secs(1)).await;

--- a/examples/stm32l0xx/lora-discovery/Cargo.lock
+++ b/examples/stm32l0xx/lora-discovery/Cargo.lock
@@ -246,7 +246,7 @@ dependencies = [
 [[package]]
 name = "cortex-m"
 version = "0.7.2"
-source = "git+https://github.com/rust-embedded/cortex-m.git?branch=master#1a4e09646aa37c3408d69fe4452265f405400593"
+source = "git+https://github.com/rust-embedded/cortex-m.git?branch=master#47246ecc06f7a6665885fd19cd14f35fa390ab95"
 dependencies = [
  "bare-metal 0.2.5",
  "bitfield",
@@ -611,9 +611,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
@@ -782,9 +782,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
 name = "pin-utils"

--- a/examples/stm32l0xx/lora-discovery/src/main.rs
+++ b/examples/stm32l0xx/lora-discovery/src/main.rs
@@ -148,9 +148,11 @@ async fn main(spawner: embassy::executor::Spawner, mut p: Peripherals) {
         button: ActorContext::new(Button::new(pin)),
     });
 
-    DEVICE.mount(|device| {
-        let lora = device.lora.mount((), spawner);
-        let app = device.app.mount(AppConfig { lora }, spawner);
-        device.button.mount(app, spawner);
-    });
+    DEVICE
+        .mount(|device| async move {
+            let lora = device.lora.mount((), spawner);
+            let app = device.app.mount(AppConfig { lora }, spawner);
+            device.button.mount(app, spawner);
+        })
+        .await;
 }

--- a/examples/wasm/browser/Cargo.lock
+++ b/examples/wasm/browser/Cargo.lock
@@ -96,7 +96,7 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 [[package]]
 name = "cortex-m"
 version = "0.7.2"
-source = "git+https://github.com/rust-embedded/cortex-m.git?branch=master#1a4e09646aa37c3408d69fe4452265f405400593"
+source = "git+https://github.com/rust-embedded/cortex-m.git?branch=master#47246ecc06f7a6665885fd19cd14f35fa390ab95"
 dependencies = [
  "bare-metal 0.2.5",
  "bitfield",
@@ -392,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
 name = "pin-utils"

--- a/examples/wasm/browser/src/lib.rs
+++ b/examples/wasm/browser/src/lib.rs
@@ -11,6 +11,7 @@ use components::*;
 use system::*;
 
 use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::spawn_local;
 
 use drogue_device::{
     actors::{button::*, led::*},
@@ -52,9 +53,13 @@ pub fn main() -> Result<(), JsValue> {
         button: ActorContext::new(Button::new(button)),
     });
 
-    DEVICE.mount(|device| {
-        let led = device.led.mount((), spawner);
-        device.button.mount(led, spawner);
+    spawn_local(async move {
+        DEVICE
+            .mount(|device| async move {
+                let led = device.led.mount((), spawner);
+                device.button.mount(led, spawner);
+            })
+            .await
     });
 
     Ok(())


### PR DESCRIPTION
This adds TLS support for drogue-device.

* Make Address<Adapter> implement TcpStack, wrapping the actor for esp8266
* Introduce TcpSocket trait that is implemented by a Socket type
* Modify wifi common app to operate on a socket, not caring about the network interface
* Add TlsSocket abstraction combining drogue-tls and the Socket type
* Use TLS for the std/esp8266 example
* Make device.mount() async in order to simplify actor setup, allowing the app to use addresses to request/respond messages, which in turn implicitly controls actor setup order.