### PR TITLE
Replace mpsc

### DIFF
--- a/device/Cargo.toml
+++ b/device/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.1.0"
 doctest = false
 
 [dependencies]
-embassy = {git = "https://github.com/embassy-rs/embassy.git", rev = "0a1da180d0fd93deaf9cc453566c3d66511c03a8", default-features = false }
+embassy = {git = "https://github.com/embassy-rs/embassy.git", rev = "c458ad52e698ae0e9810e90d094394bd3ab35c77", default-features = false }
 #embassy = {default-features = false, path = "../../../embassy/embassy"}
 
 # LoRa dependencies
@@ -46,7 +46,7 @@ defmt = { version = "0.2", optional = true }
 base64 = { version = "0.13.0", default-features = false }
 
 [dev-dependencies]
-embassy-std = {git = "https://github.com/embassy-rs/embassy.git", rev = "0a1da180d0fd93deaf9cc453566c3d66511c03a8", default-features = false }
+embassy-std = {git = "https://github.com/embassy-rs/embassy.git", rev = "c458ad52e698ae0e9810e90d094394bd3ab35c77", default-features = false }
 #embassy-std = {default-features = false, path = "../../../embassy/embassy-std" }
 
 drogue-device-macros = { path = "../macros" }

--- a/device/src/kernel/mod.rs
+++ b/device/src/kernel/mod.rs
@@ -1,5 +1,5 @@
 pub mod actor;
-pub mod channel;
+mod channel;
 pub mod device;
 pub mod package;
 pub mod signal;

--- a/device/src/lib.rs
+++ b/device/src/lib.rs
@@ -3,7 +3,6 @@
 #![allow(incomplete_features)]
 #![allow(dead_code)]
 #![feature(min_type_alias_impl_trait)]
-#![feature(const_generics_defaults)]
 #![feature(const_generics)]
 #![feature(const_evaluatable_checked)]
 #![feature(impl_trait_in_bindings)]

--- a/device/src/lib.rs
+++ b/device/src/lib.rs
@@ -88,7 +88,6 @@ pub(crate) mod fmt;
 pub mod kernel;
 pub use kernel::{
     actor::{Actor, ActorContext, ActorSpawner, Address},
-    channel::Channel,
     device::DeviceContext,
     package::Package,
     util::ImmediateFuture,

--- a/examples/common/wifi/Cargo.lock
+++ b/examples/common/wifi/Cargo.lock
@@ -151,7 +151,7 @@ dependencies = [
 [[package]]
 name = "embassy"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "atomic-polyfill",
  "cast",
@@ -167,7 +167,7 @@ dependencies = [
 [[package]]
 name = "embassy-macros"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -178,7 +178,7 @@ dependencies = [
 [[package]]
 name = "embassy-traits"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "embedded-hal",
 ]

--- a/examples/nrf52/microbit-esp8266/Cargo.lock
+++ b/examples/nrf52/microbit-esp8266/Cargo.lock
@@ -361,7 +361,7 @@ dependencies = [
 [[package]]
 name = "embassy"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "atomic-polyfill",
  "cast",
@@ -377,7 +377,7 @@ dependencies = [
 [[package]]
 name = "embassy-hal-common"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "cortex-m 0.7.3",
  "embassy",
@@ -387,7 +387,7 @@ dependencies = [
 [[package]]
 name = "embassy-macros"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -398,7 +398,7 @@ dependencies = [
 [[package]]
 name = "embassy-nrf"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "cortex-m 0.7.3",
  "cortex-m-rt",
@@ -416,7 +416,7 @@ dependencies = [
 [[package]]
 name = "embassy-traits"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "embedded-hal",
 ]

--- a/examples/nrf52/microbit-esp8266/Cargo.toml
+++ b/examples/nrf52/microbit-esp8266/Cargo.toml
@@ -23,8 +23,8 @@ wifi-app = { path = "../../common/wifi" }
 cortex-m-rt = "0.6"
 cortex-m = { version = "0.6", features = ["inline-asm"] }
 
-embassy = {git = "https://github.com/embassy-rs/embassy.git", rev = "0a1da180d0fd93deaf9cc453566c3d66511c03a8", default-features = false}
-embassy-nrf = {git = "https://github.com/embassy-rs/embassy.git", rev = "0a1da180d0fd93deaf9cc453566c3d66511c03a8", default-features = false, features = ["nrf52833"]}
+embassy = {git = "https://github.com/embassy-rs/embassy.git", rev = "c458ad52e698ae0e9810e90d094394bd3ab35c77", default-features = false}
+embassy-nrf = {git = "https://github.com/embassy-rs/embassy.git", rev = "c458ad52e698ae0e9810e90d094394bd3ab35c77", default-features = false, features = ["nrf52833"]}
 nrf52833-pac = { version = "0.9", features = ["rt"] }
 #embassy = {path = "../../../../../embassy/embassy", default-features = false}
 #embassy-nrf = {path = "../../../../../embassy/embassy-nrf", default-features = false, features = ["nrf52833"]}

--- a/examples/nrf52/microbit-rak811/Cargo.lock
+++ b/examples/nrf52/microbit-rak811/Cargo.lock
@@ -196,7 +196,7 @@ dependencies = [
 [[package]]
 name = "embassy"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "atomic-polyfill",
  "cast",
@@ -212,7 +212,7 @@ dependencies = [
 [[package]]
 name = "embassy-hal-common"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "cortex-m 0.7.3",
  "embassy",
@@ -222,7 +222,7 @@ dependencies = [
 [[package]]
 name = "embassy-macros"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -233,7 +233,7 @@ dependencies = [
 [[package]]
 name = "embassy-nrf"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "cortex-m 0.7.3",
  "cortex-m-rt",
@@ -251,7 +251,7 @@ dependencies = [
 [[package]]
 name = "embassy-traits"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "embedded-hal",
 ]

--- a/examples/nrf52/microbit-rak811/Cargo.toml
+++ b/examples/nrf52/microbit-rak811/Cargo.toml
@@ -19,8 +19,8 @@ drogue-device = { path = "../../../device", features = ["lora+rak811"], default-
 cortex-m-rt = "0.6"
 cortex-m = { version = "0.6", features = ["inline-asm"] }
 
-embassy = {git = "https://github.com/embassy-rs/embassy.git", rev = "0a1da180d0fd93deaf9cc453566c3d66511c03a8", default-features = false}
-embassy-nrf = {git = "https://github.com/embassy-rs/embassy.git", rev = "0a1da180d0fd93deaf9cc453566c3d66511c03a8", default-features = false, features = ["nrf52833"]}
+embassy = {git = "https://github.com/embassy-rs/embassy.git", rev = "c458ad52e698ae0e9810e90d094394bd3ab35c77", default-features = false}
+embassy-nrf = {git = "https://github.com/embassy-rs/embassy.git", rev = "c458ad52e698ae0e9810e90d094394bd3ab35c77", default-features = false, features = ["nrf52833"]}
 #embassy = {path = "../../../../../embassy/embassy", default-features = false}
 #embassy-nrf = {path = "../../../../../embassy/embassy-nrf", default-features = false, features = ["nrf52833"]}
 

--- a/examples/nrf52/microbit-uart/Cargo.lock
+++ b/examples/nrf52/microbit-uart/Cargo.lock
@@ -233,7 +233,7 @@ dependencies = [
 [[package]]
 name = "embassy"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "atomic-polyfill",
  "cast",
@@ -249,7 +249,7 @@ dependencies = [
 [[package]]
 name = "embassy-hal-common"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "cortex-m 0.7.3",
  "embassy",
@@ -259,7 +259,7 @@ dependencies = [
 [[package]]
 name = "embassy-macros"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -270,7 +270,7 @@ dependencies = [
 [[package]]
 name = "embassy-nrf"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "cortex-m 0.7.3",
  "cortex-m-rt",
@@ -288,7 +288,7 @@ dependencies = [
 [[package]]
 name = "embassy-traits"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "embedded-hal",
 ]

--- a/examples/nrf52/microbit-uart/Cargo.toml
+++ b/examples/nrf52/microbit-uart/Cargo.toml
@@ -18,8 +18,8 @@ drogue-device = { path = "../../../device", default-features = false, features =
 cortex-m-rt = "0.6"
 cortex-m = { version = "0.6", features = ["inline-asm"] }
 
-embassy = {git = "https://github.com/embassy-rs/embassy.git", rev = "0a1da180d0fd93deaf9cc453566c3d66511c03a8", default-features = false}
-embassy-nrf = {git = "https://github.com/embassy-rs/embassy.git", rev = "0a1da180d0fd93deaf9cc453566c3d66511c03a8", default-features = false, features = ["nrf52833"]}
+embassy = {git = "https://github.com/embassy-rs/embassy.git", rev = "c458ad52e698ae0e9810e90d094394bd3ab35c77", default-features = false}
+embassy-nrf = {git = "https://github.com/embassy-rs/embassy.git", rev = "c458ad52e698ae0e9810e90d094394bd3ab35c77", default-features = false, features = ["nrf52833"]}
 #embassy = {path = "../../../../../embassy/embassy", default-features = false}
 #embassy-nrf = {path = "../../../../../embassy/embassy-nrf", default-features = false, features = ["nrf52833"]}
 

--- a/examples/rp/blinky/Cargo.lock
+++ b/examples/rp/blinky/Cargo.lock
@@ -250,7 +250,7 @@ dependencies = [
 [[package]]
 name = "embassy"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "atomic-polyfill",
  "cast",
@@ -266,7 +266,7 @@ dependencies = [
 [[package]]
 name = "embassy-hal-common"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "cortex-m 0.7.3",
  "embassy",
@@ -276,7 +276,7 @@ dependencies = [
 [[package]]
 name = "embassy-macros"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -287,7 +287,7 @@ dependencies = [
 [[package]]
 name = "embassy-rp"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "cortex-m 0.7.3",
  "cortex-m-rt",
@@ -302,7 +302,7 @@ dependencies = [
 [[package]]
 name = "embassy-traits"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "embedded-hal",
 ]

--- a/examples/rp/blinky/Cargo.toml
+++ b/examples/rp/blinky/Cargo.toml
@@ -23,8 +23,8 @@ cortex-m-rt = "0.6"
 cortex-m = { version = "0.7", features = ["inline-asm"] }
 
 # TODO: Get rid of these embassy deps some day
-embassy = {git = "https://github.com/embassy-rs/embassy.git", rev = "0a1da180d0fd93deaf9cc453566c3d66511c03a8", default-features = false}
-embassy-rp = {git = "https://github.com/embassy-rs/embassy.git", rev = "0a1da180d0fd93deaf9cc453566c3d66511c03a8", default-features = false}
+embassy = {git = "https://github.com/embassy-rs/embassy.git", rev = "c458ad52e698ae0e9810e90d094394bd3ab35c77", default-features = false}
+embassy-rp = {git = "https://github.com/embassy-rs/embassy.git", rev = "c458ad52e698ae0e9810e90d094394bd3ab35c77", default-features = false}
 
 # embassy = {path = "../../../../../embassy/embassy", default-features = false}
 # embassy-rp = {path = "../../../../../embassy/embassy-rp", default-features = false}

--- a/examples/std/esp8266/Cargo.lock
+++ b/examples/std/esp8266/Cargo.lock
@@ -384,7 +384,7 @@ dependencies = [
 [[package]]
 name = "embassy"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "atomic-polyfill",
  "cast",
@@ -400,7 +400,7 @@ dependencies = [
 [[package]]
 name = "embassy-macros"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -411,7 +411,7 @@ dependencies = [
 [[package]]
 name = "embassy-std"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "embassy",
  "embassy-macros",
@@ -421,7 +421,7 @@ dependencies = [
 [[package]]
 name = "embassy-traits"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "embedded-hal",
 ]

--- a/examples/std/esp8266/Cargo.toml
+++ b/examples/std/esp8266/Cargo.toml
@@ -14,8 +14,8 @@ log = "0.4"
 env_logger = "0.8"
 drogue-device = { path = "../../../device", features = ["log", "std", "wifi+esp8266", "tls"] }
 drogue-tls = { version = "0.2.0", default-features = false, features = ["async"], optional = true}
-embassy = {git = "https://github.com/embassy-rs/embassy.git", rev = "0a1da180d0fd93deaf9cc453566c3d66511c03a8", features = ["std"] }
-embassy-std = {git = "https://github.com/embassy-rs/embassy.git", rev = "0a1da180d0fd93deaf9cc453566c3d66511c03a8", default-features = false }
+embassy = {git = "https://github.com/embassy-rs/embassy.git", rev = "c458ad52e698ae0e9810e90d094394bd3ab35c77", features = ["std"] }
+embassy-std = {git = "https://github.com/embassy-rs/embassy.git", rev = "c458ad52e698ae0e9810e90d094394bd3ab35c77", default-features = false }
 rand = "0.8"
 cfg-if = "1.0.0"
 

--- a/examples/std/hello/Cargo.lock
+++ b/examples/std/hello/Cargo.lock
@@ -172,7 +172,7 @@ dependencies = [
 [[package]]
 name = "embassy"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "atomic-polyfill",
  "cast",
@@ -188,7 +188,7 @@ dependencies = [
 [[package]]
 name = "embassy-macros"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -199,7 +199,7 @@ dependencies = [
 [[package]]
 name = "embassy-std"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "embassy",
  "embassy-macros",
@@ -209,7 +209,7 @@ dependencies = [
 [[package]]
 name = "embassy-traits"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "embedded-hal",
 ]

--- a/examples/std/hello/Cargo.toml
+++ b/examples/std/hello/Cargo.toml
@@ -13,8 +13,8 @@ version = "0.1.0"
 log = "0.4"
 env_logger = "0.8"
 drogue-device = { path = "../../../device", features = ["log", "std"] }
-embassy = {git = "https://github.com/embassy-rs/embassy.git", rev = "0a1da180d0fd93deaf9cc453566c3d66511c03a8", features = ["std"] }
-embassy-std = {git = "https://github.com/embassy-rs/embassy.git", rev = "0a1da180d0fd93deaf9cc453566c3d66511c03a8", default-features = false }
+embassy = {git = "https://github.com/embassy-rs/embassy.git", rev = "c458ad52e698ae0e9810e90d094394bd3ab35c77", features = ["std"] }
+embassy-std = {git = "https://github.com/embassy-rs/embassy.git", rev = "c458ad52e698ae0e9810e90d094394bd3ab35c77", default-features = false }
 
 [patch.crates-io]
 cortex-m = {git = "https://github.com/rust-embedded/cortex-m.git", branch = "master", features = ["device"]}

--- a/examples/stm32l0xx/lora-discovery/Cargo.lock
+++ b/examples/stm32l0xx/lora-discovery/Cargo.lock
@@ -423,7 +423,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 [[package]]
 name = "embassy"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "atomic-polyfill",
  "cast",
@@ -439,7 +439,7 @@ dependencies = [
 [[package]]
 name = "embassy-hal-common"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "cortex-m 0.7.3",
  "embassy",
@@ -449,7 +449,7 @@ dependencies = [
 [[package]]
 name = "embassy-macros"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -460,7 +460,7 @@ dependencies = [
 [[package]]
 name = "embassy-stm32"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "atomic-polyfill",
  "bare-metal 1.0.0",
@@ -484,7 +484,7 @@ dependencies = [
 [[package]]
 name = "embassy-traits"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "embedded-hal",
 ]
@@ -1070,7 +1070,7 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 [[package]]
 name = "stm32-metapac"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "cortex-m 0.7.3",
  "cortex-m-rt",
@@ -1081,7 +1081,7 @@ dependencies = [
 [[package]]
 name = "stm32-metapac-gen"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "chiptool",
  "proc-macro2",

--- a/examples/stm32l0xx/lora-discovery/Cargo.toml
+++ b/examples/stm32l0xx/lora-discovery/Cargo.toml
@@ -24,8 +24,8 @@ heapless = "0.6"
 void = { version = "1", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 
-embassy = {git = "https://github.com/embassy-rs/embassy.git", rev = "0a1da180d0fd93deaf9cc453566c3d66511c03a8", default-features = false}
-embassy-stm32 = {git = "https://github.com/embassy-rs/embassy.git", rev = "0a1da180d0fd93deaf9cc453566c3d66511c03a8", default-features = false, features = ["stm32l072cz"] }
+embassy = {git = "https://github.com/embassy-rs/embassy.git", rev = "c458ad52e698ae0e9810e90d094394bd3ab35c77", default-features = false}
+embassy-stm32 = {git = "https://github.com/embassy-rs/embassy.git", rev = "c458ad52e698ae0e9810e90d094394bd3ab35c77", default-features = false, features = ["stm32l072cz"] }
 
 #embassy = {path = "../../../../../embassy/embassy", default-features = false}
 #embassy-stm32 = {path = "../../../../../embassy/embassy-stm32", default-features = false, features = ["stm32l072cz"] }

--- a/examples/wasm/browser/Cargo.lock
+++ b/examples/wasm/browser/Cargo.lock
@@ -174,7 +174,7 @@ dependencies = [
 [[package]]
 name = "embassy"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "atomic-polyfill",
  "cast",
@@ -190,7 +190,7 @@ dependencies = [
 [[package]]
 name = "embassy-macros"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -201,7 +201,7 @@ dependencies = [
 [[package]]
 name = "embassy-traits"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=0a1da180d0fd93deaf9cc453566c3d66511c03a8#0a1da180d0fd93deaf9cc453566c3d66511c03a8"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=c458ad52e698ae0e9810e90d094394bd3ab35c77#c458ad52e698ae0e9810e90d094394bd3ab35c77"
 dependencies = [
  "embedded-hal",
 ]

--- a/examples/wasm/browser/Cargo.toml
+++ b/examples/wasm/browser/Cargo.toml
@@ -18,7 +18,7 @@ wasm-logger = "0.2.0"
 log = "0.4"
 
 drogue-device = { path = "../../../device", features = ["log"], default-features = false }
-embassy = {git = "https://github.com/embassy-rs/embassy.git", rev = "0a1da180d0fd93deaf9cc453566c3d66511c03a8", default-features = false, features = ["executor-agnostic"] }
+embassy = {git = "https://github.com/embassy-rs/embassy.git", rev = "c458ad52e698ae0e9810e90d094394bd3ab35c77", default-features = false, features = ["executor-agnostic"] }
 #embassy = {default-features = false, path = "../../../../../embassy/embassy", features = ["executor-agnostic"] }
 
 critical-section = { version = "0.2.1", features = ["custom-impl"] }


### PR DESCRIPTION
Replace the channel implementation using the new one from embassy. Actor channel is still using the existing implementation, mainly due to not yet finding a way to use const generics from assoc types.