### PR TITLE
Ensure message is not alive after response is sent

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,12 +70,10 @@ impl Actor for Counter {
     {
         async move {
             loop {
-                // Await the next message and invoke the provided closure. If the processing loop needs to
-                // invoke other async functions, you can use inbox.next() to retrieve an item together with a
-                // responder instance.
-                inbox.process(|m| {
+                // Await the next message and increment the counter
+                if let Some(m) = inbox.next().await {
                     self.count += 1;
-                }).await;
+                }
             }
         }
     }

--- a/device/src/actors/led/matrix.rs
+++ b/device/src/actors/led/matrix.rs
@@ -116,7 +116,7 @@ where
         async move {
             loop {
                 match with_timeout(self.refresh_delay, inbox.next()).await {
-                    Ok(Some((message, r))) => r.respond(match message {
+                    Ok(Some(mut m)) => match *m.message() {
                         MatrixCommand::ApplyFrame(f) => self.apply(f.to_frame()),
                         MatrixCommand::On(x, y) => self.on(x, y),
                         MatrixCommand::Off(x, y) => self.off(x, y),
@@ -124,7 +124,7 @@ where
                         MatrixCommand::Render => {
                             self.render();
                         }
-                    }),
+                    },
                     Err(TimeoutError) => {
                         self.render();
                     }

--- a/device/src/actors/led/mod.rs
+++ b/device/src/actors/led/mod.rs
@@ -67,23 +67,21 @@ where
     {
         async move {
             loop {
-                inbox
-                    .process(|message| {
-                        let new_state = match message {
-                            LedMessage::On => true,
-                            LedMessage::Off => false,
-                            LedMessage::State(state) => state,
-                            LedMessage::Toggle => !self.state,
+                if let Some(mut m) = inbox.next().await {
+                    let new_state = match *m.message() {
+                        LedMessage::On => true,
+                        LedMessage::Off => false,
+                        LedMessage::State(state) => state,
+                        LedMessage::Toggle => !self.state,
+                    };
+                    if self.state != new_state {
+                        self.state = new_state;
+                        match self.state {
+                            true => self.pin.set_high().ok(),
+                            false => self.pin.set_low().ok(),
                         };
-                        if self.state != new_state {
-                            self.state = new_state;
-                            match self.state {
-                                true => self.pin.set_high().ok(),
-                                false => self.pin.set_low().ok(),
-                            };
-                        }
-                    })
-                    .await;
+                    }
+                }
             }
         }
     }

--- a/device/src/actors/ticker.rs
+++ b/device/src/actors/ticker.rs
@@ -59,8 +59,8 @@ where
         async move {
             self.me.unwrap().notify(TickerCommand::Start).unwrap();
             loop {
-                if let Some((message, r)) = inbox.next().await {
-                    r.respond(match message {
+                if let Some(mut m) = inbox.next().await {
+                    match m.message() {
                         TickerCommand::Tick => {
                             if self.running {
                                 // Wait the configured interval before sending the message
@@ -80,7 +80,7 @@ where
                         TickerCommand::Stop => {
                             self.running = false;
                         }
-                    });
+                    }
                 }
             }
         }

--- a/device/src/actors/timer.rs
+++ b/device/src/actors/timer.rs
@@ -50,16 +50,16 @@ impl<'a, A: Actor + 'a> Actor for Timer<'a, A> {
     {
         async move {
             loop {
-                if let Some((message, responder)) = inbox.next().await {
-                    responder.respond(match message {
+                if let Some(mut m) = inbox.next().await {
+                    match m.message() {
                         TimerMessage::Delay(dur) => {
-                            time::Timer::after(dur).await;
+                            time::Timer::after(*dur).await;
                         }
-                        TimerMessage::Schedule(dur, address, mut message) => {
-                            time::Timer::after(dur).await;
+                        TimerMessage::Schedule(dur, address, message) => {
+                            time::Timer::after(*dur).await;
                             let _ = address.notify(message.take().unwrap());
                         }
-                    });
+                    };
                 }
             }
         }

--- a/device/src/testutil.rs
+++ b/device/src/testutil.rs
@@ -119,8 +119,9 @@ impl Actor for DummyActor {
     {
         async move {
             loop {
-                let (_, r) = inbox.next().await.unwrap();
-                r.respond(());
+                if let Some(mut m) = inbox.next().await {
+                    m.set_response(());
+                }
             }
         }
     }
@@ -153,9 +154,8 @@ impl Actor for TestHandler {
     {
         async move {
             loop {
-                let (message, responder) = inbox.next().await.unwrap();
-                self.on_message.signal(message);
-                responder.respond(());
+                let mut message = inbox.next().await.unwrap();
+                self.on_message.signal(*message.message());
             }
         }
     }

--- a/device/src/traits/ip.rs
+++ b/device/src/traits/ip.rs
@@ -44,7 +44,7 @@ impl Display for IpAddressV4 {
     }
 }
 
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct SocketAddress {
     ip: IpAddress,
@@ -65,6 +65,7 @@ impl SocketAddress {
     }
 }
 
+#[derive(Clone, Copy)]
 pub enum IpProtocol {
     Tcp,
     Udp,

--- a/device/src/traits/wifi.rs
+++ b/device/src/traits/wifi.rs
@@ -1,14 +1,14 @@
 use super::ip::IpAddress;
 use core::future::Future;
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Join<'a> {
     Open,
     Wpa { ssid: &'a str, password: &'a str },
 }
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum JoinError {
     Unknown,

--- a/device/tests/integration_tests.rs
+++ b/device/tests/integration_tests.rs
@@ -37,9 +37,8 @@ mod tests {
             {
                 async move {
                     loop {
-                        let (message, responder) = inbox.next().await.unwrap();
-                        self.value.fetch_add(message.0, Ordering::SeqCst);
-                        responder.respond(());
+                        let mut message = inbox.next().await.unwrap();
+                        self.value.fetch_add(message.message().0, Ordering::SeqCst);
                     }
                 }
             }

--- a/docs/modules/ROOT/pages/drivers.adoc
+++ b/docs/modules/ROOT/pages/drivers.adoc
@@ -63,14 +63,16 @@ impl Counter for MyCounter {
     type IncrementFuture<'m> = impl Future<Output = u32> + 'm;
     fn increment<'m>(&'m mut self) -> Self::IncrementFuture<'m> {
         async move {
-            self.counter += 1;
+            self.value += 1;
+            self.value
         }
     }
 
     type AddFuture<'m> = impl Future<Output = u32> + 'm;
     fn add<'m>(&'m mut self, value: u32) -> Self::AddFuture<'m> {
         async move {
-            self.counter += value;
+            self.value += value;
+            self.value
         }
     }
 }
@@ -116,11 +118,13 @@ impl Actor for AtomicCounter {
     {
         async move {
             loop {
-                if let Some((message, responder)) = inbox.next().await {
-                    responder.respond(match message {
+                if let Some(m) = inbox.next().await {
+                    let value = match m.message() {
                         CounterMessage::Increment => self.counter.increment().await,
-                        CounterMessage::Add(value) => self.counter.add(value).await,
-                    });
+                        CounterMessage::Add(value) => self.counter.add(*value).await,
+                    }
+                    // Set the response value
+                    message.set_response(value);
                 }
             }
         }

--- a/examples/common/wifi/src/lib.rs
+++ b/examples/common/wifi/src/lib.rs
@@ -75,7 +75,7 @@ where
         async move {
             loop {
                 match inbox.next().await {
-                    Some((message, r)) => r.respond(match message {
+                    Some(mut m) => match m.message() {
                         Command::Send => {
                             log::info!("Sending data");
                             let socket = self.socket.as_mut().unwrap();
@@ -103,7 +103,7 @@ where
                                 );
                             }
                         }
-                    }),
+                    },
                     _ => {}
                 }
             }

--- a/examples/nrf52/microbit/rak811/src/app.rs
+++ b/examples/nrf52/microbit/rak811/src/app.rs
@@ -61,13 +61,13 @@ impl<D: LoraDriver> Actor for App<D> {
             let driver = self.driver.as_mut().unwrap();
             loop {
                 match inbox.next().await {
-                    Some((m, r)) => r.respond(match m {
+                    Some(mut m) => match m.message() {
                         Command::Send => {
                             log::info!("Sending data..");
                             let result = driver.send(QoS::Confirmed, 1, b"ping").await;
                             log::info!("Data sent: {:?}", result);
                         }
-                    }),
+                    },
                     _ => {}
                 }
             }

--- a/examples/nrf52/microbit/uart/src/statistics.rs
+++ b/examples/nrf52/microbit/uart/src/statistics.rs
@@ -47,14 +47,14 @@ impl Actor for Statistics {
     {
         async move {
             loop {
-                inbox
-                    .process(|message| match message {
+                if let Some(mut m) = inbox.next().await {
+                    match *m.message() {
                         StatisticsCommand::PrintStatistics => {
                             defmt::info!("Character count: {}", self.character_counter)
                         }
                         StatisticsCommand::IncrementCharacterCount => self.character_counter += 1,
-                    })
-                    .await;
+                    }
+                }
             }
         }
     }

--- a/examples/std/hello/src/myactor.rs
+++ b/examples/std/hello/src/myactor.rs
@@ -36,10 +36,10 @@ impl Actor for MyActor {
             log::info!("[{}] started!", self.name);
             loop {
                 match inbox.next().await {
-                    Some((m, r)) => r.respond({
+                    Some(mut m) => {
                         let count = self.counter.unwrap().fetch_add(1, Ordering::SeqCst);
-                        log::info!("[{}] hello {}: {}", self.name, m.0, count);
-                    }),
+                        log::info!("[{}] hello {}: {}", self.name, m.message().0, count);
+                    }
                     _ => {}
                 }
             }

--- a/examples/stm32h7/nucleo-h743zi/blinkdance/src/main.rs
+++ b/examples/stm32h7/nucleo-h743zi/blinkdance/src/main.rs
@@ -9,7 +9,6 @@ use defmt_rtt as _;
 use panic_probe as _;
 
 use core::future::Future;
-use core::pin::Pin;
 use drogue_device::actors::button::{ButtonEvent, FromButtonEvent};
 use drogue_device::actors::led::{Led, LedMessage};
 use drogue_device::{actors::button::Button, Actor, ActorContext, Address, DeviceContext, Inbox};
@@ -130,7 +129,7 @@ impl Actor for App {
         async move {
             loop {
                 match with_timeout(Duration::from_millis(50), inbox.next()).await {
-                    Ok(Some((message, r))) => r.respond(match message {
+                    Ok(Some(mut m)) => match m.message() {
                         Command::StartDancing => {
                             self.all_on();
                             self.dancing = true;
@@ -139,7 +138,7 @@ impl Actor for App {
                             self.dancing = false;
                             self.all_off();
                         }
-                    }),
+                    },
                     _ => {}
                 }
                 if self.dancing {

--- a/examples/stm32h7/nucleo-h743zi/blinky/src/main.rs
+++ b/examples/stm32h7/nucleo-h743zi/blinky/src/main.rs
@@ -103,7 +103,7 @@ impl Actor for App {
         async move {
             loop {
                 match inbox.next().await {
-                    Some((_, r)) => r.respond(match self.color {
+                    Some(m) => match self.color {
                         None | Some(Color::Red) => {
                             self.color = Some(Color::Green);
                         }
@@ -113,7 +113,7 @@ impl Actor for App {
                         Some(Color::Yellow) => {
                             self.color = Some(Color::Red);
                         }
-                    }),
+                    },
                     _ => {}
                 }
 

--- a/examples/stm32l0/lora-discovery/src/app.rs
+++ b/examples/stm32l0/lora-discovery/src/app.rs
@@ -183,7 +183,7 @@ where
             self.config.init_led.off().ok();
             loop {
                 match inbox.next().await {
-                    Some((message, responder)) => responder.respond(match message {
+                    Some(mut m) => match m.message() {
                         Command::Tick => {
                             self.tick();
                         }
@@ -194,7 +194,7 @@ where
                             self.tick();
                             self.send().await;
                         }
-                    }),
+                    },
                     _ => {}
                 }
             }


### PR DESCRIPTION
Prevent the possibility of accidentally responding before a message is processed. Introduce an InboxMessage
type that ensures an owned message is not used beyond that of the response signal

Introduce a Default trait requirement for Responses to ensure safe default handling.