### PR TITLE
Refactor configuration to support more config file locations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@
 
 # IntelliJ
 .idea/
+
+# Drogue config
+**/.drogue/

--- a/examples/_build/Cargo.lock
+++ b/examples/_build/Cargo.lock
@@ -34,6 +34,7 @@ name = "buildutil"
 version = "0.1.0"
 dependencies = [
  "config",
+ "lazy_static",
 ]
 
 [[package]]

--- a/examples/_build/Cargo.toml
+++ b/examples/_build/Cargo.toml
@@ -7,5 +7,6 @@ edition = "2021"
 
 [dependencies]
 config = "0.11"
+lazy_static = "1"
 
 [workspace]

--- a/examples/_build/src/lib.rs
+++ b/examples/_build/src/lib.rs
@@ -1,39 +1,66 @@
-use config;
+use config::{Config, File};
+use lazy_static::lazy_static;
 use std::collections::HashMap;
 use std::env;
 use std::fs::{self, OpenOptions};
 use std::path::{Path, PathBuf};
 
-pub fn copy_config(out: &PathBuf, manifest_dir: &PathBuf, file: &str) {
-    let file_path = manifest_dir.join(file);
+const CONFIG_FILE: &str = ".drogue/config.toml";
+const CI_ENV_VAR: &str = "CI";
+
+lazy_static! {
+    // Configuration entries are pulled from the CONFIG_FILE found
+    // beneath $HOME and the project manifest directory. Additionally,
+    // all the latter's parents will be searched. Precendence is
+    // determined by the order of calls to merge(), i.e. last merge
+    // "wins". The CONFIG_FILE beneath $HOME has the lowest
+    // precendence.
+    static ref CONFIG: HashMap<String, String> = {
+        let mut config = Config::default();
+        let global = PathBuf::from(env::var_os("HOME").unwrap()).join(CONFIG_FILE);
+        if global.is_file() {
+            println!("cargo:rerun-if-changed={}", global.display());
+            config.merge(File::from(global.as_path())).unwrap();
+        }
+        let mut path = PathBuf::new();
+        for c in PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap()).components() {
+            path.push(c);
+            let local = path.join(CONFIG_FILE);
+            if local.is_file() && local != global {
+                println!("cargo:rerun-if-changed={}", local.display());
+                config.merge(File::from(local)).unwrap();
+            }
+        }
+        config.try_into().unwrap_or(HashMap::default())
+    };
+}
+
+pub fn copy_file(filename: &str) {
+    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    let manifest_dir = &PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
+    let file_path = manifest_dir.join(filename);
     if Path::new(&file_path).exists() {
-        fs::copy(&file, out.join(file)).expect("error copying file");
+        fs::copy(&file_path, out.join(filename)).expect("error copying file");
         println!("cargo:rerun-if-changed={}", file_path.display());
     } else {
         let _ = OpenOptions::new()
             .write(true)
             .create_new(true)
-            .open(out.join(file));
+            .open(out.join(filename));
     }
 }
 
-pub fn write_config(out: &PathBuf, key: &str, value: &str) {
+pub fn write_config(key: &str, value: &str) {
+    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
     fs::write(out.join(key), value).expect("Unable to write config file");
 }
 
-pub fn configure(out: &PathBuf, keys: &[&str]) {
-    let cfg = PathBuf::from(env::var_os("HOME").unwrap()).join(".drogue/config.toml");
-    println!("cargo:rerun-if-changed={}", cfg.display());
-    let mut settings = config::Config::default();
-    let filename = cfg.to_str().unwrap();
-    settings
-        .merge(config::File::with_name(filename).required(false))
-        .unwrap();
-    let map = settings.try_into::<HashMap<String, String>>().unwrap();
-    for key in keys {
-        match map.get(key as &str) {
-            Some(v) => write_config(out, key, v),
-            None => write_config(out, key, ""),
-        }
+pub fn configure(key: &str) {
+    match CONFIG.get(key) {
+        Some(v) => write_config(key, v),
+        None => match env::var_os(CI_ENV_VAR) {
+            Some(_) => write_config(key, CI_ENV_VAR),
+            None => panic!("`{}` missing from ~/{}", key, CONFIG_FILE),
+        },
     }
 }

--- a/examples/nrf52/microbit/Cargo.lock
+++ b/examples/nrf52/microbit/Cargo.lock
@@ -203,6 +203,7 @@ name = "buildutil"
 version = "0.1.0"
 dependencies = [
  "config",
+ "lazy_static",
 ]
 
 [[package]]

--- a/examples/nrf52/microbit/ble-temperature/build.rs
+++ b/examples/nrf52/microbit/ble-temperature/build.rs
@@ -12,9 +12,7 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
-    let manifest_dir = &PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
+    buildutil::copy_file("memory.x");
     let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
-
-    buildutil::copy_config(&out, &manifest_dir, "memory.x");
     println!("cargo:rustc-link-search={}", out.display());
 }

--- a/examples/nrf52/microbit/compass/build.rs
+++ b/examples/nrf52/microbit/compass/build.rs
@@ -12,9 +12,7 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
-    let manifest_dir = &PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
+    buildutil::copy_file("memory.x");
     let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
-
-    buildutil::copy_config(&out, &manifest_dir, "memory.x");
     println!("cargo:rustc-link-search={}", out.display());
 }

--- a/examples/nrf52/microbit/esp8266/build.rs
+++ b/examples/nrf52/microbit/esp8266/build.rs
@@ -8,22 +8,16 @@
 //! updating `memory.x` ensures a rebuild of the application with the
 //! new memory settings.
 
-use buildutil::{configure, copy_config};
+use buildutil::{configure, copy_file};
 use std::env;
 use std::path::PathBuf;
 
 fn main() {
-    let manifest_dir = &PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
     let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
-    configure(
-        &out,
-        &[
-            "wifi-ssid",
-            "wifi-password",
-            "http-username",
-            "http-password",
-        ],
-    );
-    copy_config(&out, &manifest_dir, "memory.x");
+    configure("wifi-ssid");
+    configure("wifi-password");
+    configure("http-username");
+    configure("http-password");
+    copy_file("memory.x");
     println!("cargo:rustc-link-search={}", out.display());
 }

--- a/examples/nrf52/microbit/rak811/build.rs
+++ b/examples/nrf52/microbit/rak811/build.rs
@@ -8,15 +8,16 @@
 //! updating `memory.x` ensures a rebuild of the application with the
 //! new memory settings.
 
-use buildutil::{configure, copy_config};
+use buildutil::{configure, copy_file};
 use std::env;
 use std::path::PathBuf;
 
 fn main() {
-    let manifest_dir = &PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
-    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
+    configure("dev-eui");
+    configure("app-eui");
+    configure("app-key");
+    copy_file("memory.x");
 
-    configure(&out, &["dev-eui", "app-eui", "app-key"]);
-    copy_config(&out, &manifest_dir, "memory.x");
+    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
     println!("cargo:rustc-link-search={}", out.display());
 }

--- a/examples/nrf52/microbit/uart/build.rs
+++ b/examples/nrf52/microbit/uart/build.rs
@@ -12,9 +12,7 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
-    let manifest_dir = &PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
+    buildutil::copy_file("memory.x");
     let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
-
-    buildutil::copy_config(&out, &manifest_dir, "memory.x");
     println!("cargo:rustc-link-search={}", out.display());
 }

--- a/examples/rp/pico/Cargo.lock
+++ b/examples/rp/pico/Cargo.lock
@@ -95,6 +95,7 @@ name = "buildutil"
 version = "0.1.0"
 dependencies = [
  "config",
+ "lazy_static",
 ]
 
 [[package]]

--- a/examples/rp/pico/blinky/build.rs
+++ b/examples/rp/pico/blinky/build.rs
@@ -12,9 +12,7 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
-    let manifest_dir = &PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").unwrap());
+    buildutil::copy_file("memory.x");
     let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
-
-    buildutil::copy_config(&out, &manifest_dir, "memory.x");
     println!("cargo:rustc-link-search={}", out.display());
 }

--- a/examples/std/Cargo.lock
+++ b/examples/std/Cargo.lock
@@ -182,6 +182,7 @@ name = "buildutil"
 version = "0.1.0"
 dependencies = [
  "config",
+ "lazy_static",
 ]
 
 [[package]]

--- a/examples/std/cloud/build.rs
+++ b/examples/std/cloud/build.rs
@@ -8,13 +8,11 @@
 //! updating `memory.x` ensures a rebuild of the application with the
 //! new memory settings.
 
-use std::env;
-use std::path::PathBuf;
+use buildutil::configure;
 
 fn main() {
-    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
-
-    buildutil::configure(&out, &["http-username", "http-password"]);
+    configure("http-username");
+    configure("http-password");
 
     // By default, Cargo will re-run a build script whenever
     // any file in the project changes. By specifying `memory.x`

--- a/examples/std/esp8266/build.rs
+++ b/examples/std/esp8266/build.rs
@@ -8,20 +8,13 @@
 //! updating `memory.x` ensures a rebuild of the application with the
 //! new memory settings.
 
-use std::env;
-use std::path::PathBuf;
+use buildutil::configure;
 
 fn main() {
-    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
-    buildutil::configure(
-        &out,
-        &[
-            "wifi-ssid",
-            "wifi-password",
-            "http-username",
-            "http-password",
-        ],
-    );
+    configure("wifi-ssid");
+    configure("wifi-password");
+    configure("http-username");
+    configure("http-password");
 
     // By default, Cargo will re-run a build script whenever
     // any file in the project changes. By specifying `memory.x`

--- a/examples/stm32h7/nucleo-h743zi/Cargo.lock
+++ b/examples/stm32h7/nucleo-h743zi/Cargo.lock
@@ -208,6 +208,7 @@ name = "buildutil"
 version = "0.1.0"
 dependencies = [
  "config",
+ "lazy_static",
 ]
 
 [[package]]

--- a/examples/stm32h7/nucleo-h743zi/ethernet/build.rs
+++ b/examples/stm32h7/nucleo-h743zi/ethernet/build.rs
@@ -8,13 +8,11 @@
 //! updating `memory.x` ensures a rebuild of the application with the
 //! new memory settings.
 
-use std::env;
-use std::path::PathBuf;
+use buildutil::configure;
 
 fn main() {
-    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
-
-    buildutil::configure(&out, &["http-username", "http-password"]);
+    configure("http-username");
+    configure("http-password");
 
     // By default, Cargo will re-run a build script whenever
     // any file in the project changes. By specifying `memory.x`

--- a/examples/stm32l0/lora-discovery/Cargo.lock
+++ b/examples/stm32l0/lora-discovery/Cargo.lock
@@ -146,6 +146,7 @@ name = "buildutil"
 version = "0.1.0"
 dependencies = [
  "config",
+ "lazy_static",
 ]
 
 [[package]]

--- a/examples/stm32l0/lora-discovery/build.rs
+++ b/examples/stm32l0/lora-discovery/build.rs
@@ -8,13 +8,12 @@
 //! updating `memory.x` ensures a rebuild of the application with the
 //! new memory settings.
 
-use std::env;
-use std::path::PathBuf;
+use buildutil::configure;
 
 fn main() {
-    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
-
-    buildutil::configure(&out, &["dev-eui", "app-eui", "app-key"]);
+    configure("dev-eui");
+    configure("app-eui");
+    configure("app-key");
 
     // By default, Cargo will re-run a build script whenever
     // any file in the project changes. By specifying `memory.x`

--- a/examples/stm32l1/rak811/Cargo.lock
+++ b/examples/stm32l1/rak811/Cargo.lock
@@ -134,6 +134,7 @@ name = "buildutil"
 version = "0.1.0"
 dependencies = [
  "config",
+ "lazy_static",
 ]
 
 [[package]]

--- a/examples/stm32l1/rak811/build.rs
+++ b/examples/stm32l1/rak811/build.rs
@@ -8,13 +8,12 @@
 //! updating `memory.x` ensures a rebuild of the application with the
 //! new memory settings.
 
-use std::env;
-use std::path::PathBuf;
+use buildutil::configure;
 
 fn main() {
-    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
-
-    buildutil::configure(&out, &["dev-eui", "app-eui", "app-key"]);
+    configure("dev-eui");
+    configure("app-eui");
+    configure("app-key");
 
     // By default, Cargo will re-run a build script whenever
     // any file in the project changes. By specifying `memory.x`

--- a/examples/stm32l4/iot01a-wifi/Cargo.lock
+++ b/examples/stm32l4/iot01a-wifi/Cargo.lock
@@ -169,6 +169,7 @@ name = "buildutil"
 version = "0.1.0"
 dependencies = [
  "config",
+ "lazy_static",
 ]
 
 [[package]]

--- a/examples/stm32l4/iot01a-wifi/build.rs
+++ b/examples/stm32l4/iot01a-wifi/build.rs
@@ -8,21 +8,13 @@
 //! updating `memory.x` ensures a rebuild of the application with the
 //! new memory settings.
 
-use std::env;
-use std::path::PathBuf;
+use buildutil::configure;
 
 fn main() {
-    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
-
-    buildutil::configure(
-        &out,
-        &[
-            "wifi-ssid",
-            "wifi-password",
-            "http-username",
-            "http-password",
-        ],
-    );
+    configure("wifi-ssid");
+    configure("wifi-password");
+    configure("http-username");
+    configure("http-password");
 
     // By default, Cargo will re-run a build script whenever
     // any file in the project changes. By specifying `memory.x`

--- a/examples/stm32wl/nucleo-wl55/Cargo.lock
+++ b/examples/stm32wl/nucleo-wl55/Cargo.lock
@@ -134,6 +134,7 @@ name = "buildutil"
 version = "0.1.0"
 dependencies = [
  "config",
+ "lazy_static",
 ]
 
 [[package]]

--- a/examples/stm32wl/nucleo-wl55/build.rs
+++ b/examples/stm32wl/nucleo-wl55/build.rs
@@ -8,14 +8,12 @@
 //! updating `memory.x` ensures a rebuild of the application with the
 //! new memory settings.
 
-use std::env;
-use std::path::PathBuf;
+use buildutil::configure;
 
 fn main() {
-    let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
-
-    // Copy credentials
-    buildutil::configure(&out, &["dev-eui", "app-eui", "app-key"]);
+    configure("dev-eui");
+    configure("app-eui");
+    configure("app-key");
 
     // By default, Cargo will re-run a build script whenever
     // any file in the project changes. By specifying `memory.x`


### PR DESCRIPTION
Configuration entries are pulled from the `.drogue/config.toml` found
beneath $HOME and the project manifest directory, typically
$PWD. Additionally, all the latter's parents will be
searched. Precendence is determined by the order of calls to
Config::merge(), so we start from the root and search down through the
manifest dir components i.e. last merge "wins". The
`.drogue/config.toml` beneath $HOME has the lowest precendence.

We also fail the compile if any entries are missing like we used
to. We can give a little better error message referencing
`.drogue/config.toml` and the missing value.

The next step is to create a proc macro that can query the
now-lazily-created static CONFIG hashmap and avoid all the file
inclusion of the files we're still creating from the CONFIG entries.