### PR TITLE
Remove need for embassy main macro

### DIFF
--- a/device/src/bsp/boards/stm32u5/b_u585i_iot02a.rs
+++ b/device/src/bsp/boards/stm32u5/b_u585i_iot02a.rs
@@ -25,9 +25,10 @@ pub struct Iot02a {
 }
 
 impl Board for Iot02a {
-    type Peripherals = embassy_stm32::Peripherals;
+    type Config = embassy_stm32::Config;
 
-    fn new(p: Self::Peripherals) -> Self {
+    fn new(config: Self::Config) -> Self {
+        let p = embassy_stm32::init(config);
         Self {
             led_blue: Led::new(Output::new(p.PE13, Level::High, Speed::Low)),
             led_green: Led::new(Output::new(p.PH7, Level::High, Speed::Low)),

--- a/examples/bsp/iot02a/src/main.rs
+++ b/examples/bsp/iot02a/src/main.rs
@@ -6,13 +6,13 @@
 #![feature(generic_associated_types)]
 
 use bsp_blinky_app::{BlinkyApp, BlinkyBoard};
+use cortex_m_rt::entry;
 use drogue_device::{bind_bsp, boot_bsp, DeviceContext};
 use embassy_stm32::dbgmcu::Dbgmcu;
-use embassy_stm32::Peripherals;
 
 use defmt_rtt as _;
 use drogue_device::bsp::boards::stm32u5::b_u585i_iot02a::{Iot02a, LedRed, UserButton};
-use drogue_device::bsp::{boot, App, AppBoard};
+use drogue_device::bsp::{boot, App, AppBoard, Board};
 use panic_probe as _;
 
 // Creates a newtype named `BSP` around the `Iot02a` to avoid
@@ -39,11 +39,11 @@ impl AppBoard<BlinkyApp<Self>> for BSP {
     }
 }
 
-#[embassy::main]
-async fn main(spawner: embassy::executor::Spawner, p: Peripherals) {
+#[entry]
+fn main() -> ! {
     unsafe {
         Dbgmcu::enable_all();
     }
-
-    boot_bsp!(BlinkyApp, BSP, p, spawner);
+    let config = Default::default();
+    boot_bsp!(BlinkyApp, BSP, config);
 }


### PR DESCRIPTION
I'm not fully convinced this is a good change or not. The problem is that now the embassy module dependency is 'hidden' in the boot_bsp macro. Other than that, its a nice improvement because now that we have board specific config, we also know which chip family to use.