### PR TITLE
Fix typo and warnings in Counter example

### DIFF
--- a/device/src/lib.rs
+++ b/device/src/lib.rs
@@ -45,7 +45,7 @@
 //!     /// to support async functions in traits such as Actor.
 //!     type OnMountFuture<'a, M> where M: 'a = impl core::future::Future<Output = ()> + 'a;
 //!
-//!     /// An actor have to implement the on_mount method. on_mount() is invoked when the internals of an actor is ready,
+//!     /// An actor has to implement the on_mount method. on_mount() is invoked when the internals of an actor is ready,
 //!     /// and the actor can begin to receive messages from an inbox.
 //!     ///
 //!     /// The following arguments are provided:
@@ -77,12 +77,12 @@
 //!     /// Actor state must be static for embassy
 //!     static COUNTER: ActorContext<Counter> = ActorContext::new();
 //!
-//!     /// Mounting the Actor will spawn an embassy task
+//!     // Mounting the Actor will spawn an embassy task
 //!     let addr = COUNTER.mount(spawner, Counter {
 //!         count: 0
 //!     });
 //!
-//!     /// The actor address may be used in any embassy task to communicate with the actor.
+//!     // The actor address may be used in any embassy task to communicate with the actor.
 //!     addr.request(Increment).unwrap().await;
 //! }
 //!```


### PR DESCRIPTION
This commit fixes a typo and also makes two doc comments into "normal"
code comments to avoid the following two warnings:
```console
warning: unused doc comment
  --> counter/src/main.rs:50:5
   |
50 |       /// Mounting the Actor will spawn an embassy task
   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
51 | /     let addr = COUNTER.mount(spawner, Counter {
52 | |         count: 0
53 | |     });
   | |_______- rustdoc does not generate documentation for statements
   |
   = note: `#[warn(unused_doc_comments)]` on by default
   = help: use `//` for a plain comment

warning: unused doc comment
  --> counter/src/main.rs:55:5
   |
55 |     /// The actor address may be used in any embassy task to
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |     communicate with the actor.
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
56 |     addr.request(Increment).unwrap().await;
   |     --------------------------------------
   |     rustdoc does not generate documentation for expressions
   |
```