### PR TITLE
Remove patch.crates-io table from temperature app

### DIFF
--- a/examples/apps/drogue-temperature/Cargo.toml
+++ b/examples/apps/drogue-temperature/Cargo.toml
@@ -25,10 +25,3 @@ rand_core = { version = "0.6.2", default-features = false }
 default = ["std"]
 tls = ["drogue-tls", "drogue-device/tls"]
 std = ["serde-json-core/std", "embassy/std"]
-
-[patch.crates-io]
-embassy = { git = "https://github.com/embassy-rs/embassy.git", rev = "c8f3ec3fba47899b123d0a146e8f9b3808ea4601" }
-#embassy-stm32 = { git = "https://github.com/embassy-rs/embassy.git", rev = "c8f3ec3fba47899b123d0a146e8f9b3808ea4601" }
-#embassy-lora = { git = "https://github.com/embassy-rs/embassy.git", rev = "c8f3ec3fba47899b123d0a146e8f9b3808ea4601" }
-#embassy-net = { git = "https://github.com/embassy-rs/embassy.git", rev = "c8f3ec3fba47899b123d0a146e8f9b3808ea4601" }
-embassy-hal-common = { git = "https://github.com/embassy-rs/embassy.git", rev = "c8f3ec3fba47899b123d0a146e8f9b3808ea4601" }


### PR DESCRIPTION
This commit removes patch.creates-io from
examples/apps/drogue-temperature/Cargo.toml as this is currently causing
the following warning:
```console
warning: patch for the non root package will be ignored, specify patch
at the workspace root:
package: examples/apps/drogue-temperature/Cargo.toml
workspace: drogue-device/Cargo.toml
```
Removing seems like the correct thing to do as this app is included as a
member of the workspace in the root Cargo.toml and will inherit/use that
files patch.crates-io.