### PR TITLE
Add missing slash to BlinkyConfiguration doc

### DIFF
--- a/examples/apps/blinky/src/lib.rs
+++ b/examples/apps/blinky/src/lib.rs
@@ -25,7 +25,7 @@ where
 /// These are the trait-based components required by the app.
 /// Members must be public so they can be slurped off.
 /// Types should reference the associated types defined
-// by the board trait above.
+/// by the board trait above.
 pub struct BlinkyConfiguration<B: BlinkyBoard> {
     pub led: B::Led,
     pub control_button: B::ControlButton,


### PR DESCRIPTION
The commit add a missing slash in the doc for the
BlinkyConfiguration struct which is causing the generated text to not
include that last line.

The docs for `apps/blinky` can be generated using the following command:
```console
$ cargo doc --features "embassy/time embassy/time-tick-32768hz" --package bsp-blinky-app:0.1.0 --open
```