### PR TITLE
Remove configuration from Actor::on_mount doc

### DIFF
--- a/device/src/kernel/actor.rs
+++ b/device/src/kernel/actor.rs
@@ -39,8 +39,8 @@ pub trait Actor: Sized {
         Self: 'm,
         M: 'm;
 
-    /// Called when an actor is mounted (activated). The actor will be provided with its expected
-    /// configuration, and address to itself, and an inbox used to receive incoming messages.
+    /// Called when an actor is mounted (activated). The actor will be provided with the
+    /// address to itself, and an inbox used to receive incoming messages.
     fn on_mount<'m, M>(&'m mut self, _: Address<Self>, _: &'m mut M) -> Self::OnMountFuture<'m, M>
     where
         M: Inbox<Self> + 'm;


### PR DESCRIPTION
This commit removes part of the doc comment for on_mount that refers to
the configuration parameter which I think was removed in
Commit de176e921ddf7eaf8f31d98912850f616b06d0bf ("Refactor actor context and simplify actor configuration").