### PR TITLE
Add module comment to bsp module

### DIFF
--- a/device/src/bsp/mod.rs
+++ b/device/src/bsp/mod.rs
@@ -1,3 +1,5 @@
+//! Board Support Packages (BSP).
+
 pub mod boards;
 
 /// A board capable of creating itself using peripherals.


### PR DESCRIPTION
This commit adds a module comment to the bsp module to help users like
myself who might not be familiar with the acronym BSP.