### PR TITLE
Add BoardConfig type to Board trait

### DIFF
--- a/device/src/bsp/boards/nrf52/adafruit_feather_sense.rs
+++ b/device/src/bsp/boards/nrf52/adafruit_feather_sense.rs
@@ -21,6 +21,7 @@ pub struct AdafruitFeatherSense {
 
 impl Board for AdafruitFeatherSense {
     type Peripherals = embassy_nrf::Peripherals;
+    type BoardConfig = ();
 
     fn new(p: Self::Peripherals) -> Self {
         Self {

--- a/device/src/bsp/boards/nrf52/microbit.rs
+++ b/device/src/bsp/boards/nrf52/microbit.rs
@@ -51,6 +51,7 @@ pub struct Microbit {
 
 impl Board for Microbit {
     type Peripherals = embassy_nrf::Peripherals;
+    type BoardConfig = ();
     fn new(p: embassy_nrf::Peripherals) -> Self {
         // LED Matrix
         let rows = [

--- a/device/src/bsp/boards/stm32h7/nucleo_h743zi.rs
+++ b/device/src/bsp/boards/stm32h7/nucleo_h743zi.rs
@@ -46,6 +46,7 @@ impl NucleoH743 {
 
 impl Board for NucleoH743 {
     type Peripherals = embassy_stm32::Peripherals;
+    type BoardConfig = ();
 
     fn new(p: Self::Peripherals) -> Self {
         static ETH_STATE: Forever<State<'static, 4, 4>> = Forever::new();

--- a/device/src/bsp/boards/stm32l0/lora_discovery.rs
+++ b/device/src/bsp/boards/stm32l0/lora_discovery.rs
@@ -63,6 +63,7 @@ impl LoraDiscovery {
 
 impl Board for LoraDiscovery {
     type Peripherals = embassy_stm32::Peripherals;
+    type BoardConfig = ();
 
     fn new(p: Self::Peripherals) -> Self {
         // SPI for sx127x

--- a/device/src/bsp/boards/stm32l1/rak811.rs
+++ b/device/src/bsp/boards/stm32l1/rak811.rs
@@ -49,6 +49,7 @@ impl Rak811 {
 
 impl Board for Rak811 {
     type Peripherals = embassy_stm32::Peripherals;
+    type BoardConfig = ();
     fn new(p: Self::Peripherals) -> Self {
         unsafe {
             let rcc = pac::RCC;

--- a/device/src/bsp/boards/stm32l4/iot01a.rs
+++ b/device/src/bsp/boards/stm32l4/iot01a.rs
@@ -68,6 +68,7 @@ impl Iot01a {
 
 impl Board for Iot01a {
     type Peripherals = embassy_stm32::Peripherals;
+    type BoardConfig = ();
 
     fn new(p: Self::Peripherals) -> Self {
         let i2c2_irq = interrupt::take!(I2C2_EV);

--- a/device/src/bsp/boards/stm32u5/b_u585i_iot02a.rs
+++ b/device/src/bsp/boards/stm32u5/b_u585i_iot02a.rs
@@ -26,6 +26,7 @@ pub struct Iot02a {
 
 impl Board for Iot02a {
     type Peripherals = embassy_stm32::Peripherals;
+    type BoardConfig = ();
 
     fn new(p: Self::Peripherals) -> Self {
         Self {

--- a/device/src/bsp/boards/stm32wl/nucleo_wl55.rs
+++ b/device/src/bsp/boards/stm32wl/nucleo_wl55.rs
@@ -47,6 +47,7 @@ impl NucleoWl55 {
 
 impl Board for NucleoWl55 {
     type Peripherals = embassy_stm32::Peripherals;
+    type BoardConfig = ();
     fn new(p: Self::Peripherals) -> Self {
         unsafe {
             pac::RCC.ccipr().modify(|w| {

--- a/device/src/bsp/mod.rs
+++ b/device/src/bsp/mod.rs
@@ -5,8 +5,13 @@ pub mod boards;
 /// A board capable of creating itself using peripherals.
 pub trait Board: Sized {
     type Peripherals;
+    type BoardConfig: Default;
 
     fn new(peripherals: Self::Peripherals) -> Self;
+
+    fn new_with_config(peripherals: Self::Peripherals, _config: Self::BoardConfig) -> Self {
+        Self::new(peripherals)
+    }
 }
 
 #[macro_export]
@@ -15,9 +20,14 @@ macro_rules! bind_bsp {
         struct $app_bsp($bsp);
         impl $crate::bsp::Board for BSP {
             type Peripherals = <$bsp as $crate::bsp::Board>::Peripherals;
+            type BoardConfig = <$bsp as $crate::bsp::Board>::BoardConfig;
 
             fn new(peripherals: Self::Peripherals) -> Self {
                 BSP(<$bsp>::new(peripherals))
+            }
+
+            fn new_with_config(peripherals: Self::Peripherals, config: Self::BoardConfig) -> Self {
+                BSP(<$bsp>::new_with_config(peripherals, config))
             }
         }
     };


### PR DESCRIPTION
This commit adds an associated type named `BoardConfig` to the `Board` trait.
The intention of this is to allow a Board to be created with a
configuration object specific to that board by using the `new_with_config`
constructor function.

A default implementation is provided for `new_with_config`, for Boards that
don't have a configuration. For those boards that don't have a config the
unit type (`()`) is set as the `BoardConfig` value.

Refs: https://github.com/drogue-iot/drogue-device/issues/169