### PR TITLE
Use crate to ensure valid uuid's, i.e. proper version & variant

### DIFF
--- a/device/Cargo.toml
+++ b/device/Cargo.toml
@@ -69,7 +69,7 @@ ccm = { version = "0.4.4", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true}
 postcard = { version = "0.7.2", optional=true }
 uluru = { version ="3.0.0", optional=true}
-
+uuid = { version = "1.0.0-alpha.1", default-features = false, optional = true }
 
 [dev-dependencies]
 embassy = { version = "0.1.0", features = ["std", "time", "time-tick-1mhz"]}
@@ -109,6 +109,7 @@ ble = []
     "postcard",
     "uluru",
     "cortex-m",
+    "uuid",
 ]
 
 "bsp+b_u585i_iot02a" = [ "embassy-stm32" ]

--- a/device/src/drivers/ble/mesh/configuration_manager.rs
+++ b/device/src/drivers/ble/mesh/configuration_manager.rs
@@ -31,7 +31,11 @@ impl Configuration {
         if self.uuid.is_none() {
             let mut uuid = [0; 16];
             rng.fill_bytes(&mut uuid);
-            self.uuid.replace(Uuid(uuid));
+            self.uuid.replace(Uuid(
+                *uuid::Builder::from_random_bytes(uuid)
+                    .into_uuid()
+                    .as_bytes(),
+            ));
             changed = true;
         }
 

--- a/examples/nrf52/nrf52840-dk/Cargo.lock
+++ b/examples/nrf52/nrf52840-dk/Cargo.lock
@@ -433,6 +433,7 @@ dependencies = [
  "rand_core",
  "serde 1.0.136",
  "uluru",
+ "uuid 1.0.0-alpha.1",
 ]
 
 [[package]]
@@ -847,7 +848,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "uuid",
+ "uuid 0.8.2",
 ]
 
 [[package]]
@@ -1296,6 +1297,12 @@ name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+
+[[package]]
+name = "uuid"
+version = "1.0.0-alpha.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb3ab47baa004111b323696c6eaa2752e7356f7f77cf6b6dc7a2087368ce1ca4"
 
 [[package]]
 name = "vcell"


### PR DESCRIPTION
The no-std and v4 features are incompatible, so following this guide:
https://docs.rs/uuid/1.0.0-alpha.1/uuid/#embedded