### PR TITLE
Remove embassy-boot patch from nrf52840-dk

### DIFF
--- a/examples/nrf52/nrf52840-dk/Cargo.lock
+++ b/examples/nrf52/nrf52840-dk/Cargo.lock
@@ -1339,8 +1339,3 @@ name = "zeroize"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c88870063c39ee00ec285a2f8d6a966e5b6fb2becc4e8dac77ed0d370ed6006"
-
-[[patch.unused]]
-name = "embassy-boot"
-version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=3d6b8bd9832d5a29cab4aa21434663e6ea6f4488#3d6b8bd9832d5a29cab4aa21434663e6ea6f4488"

--- a/examples/nrf52/nrf52840-dk/Cargo.toml
+++ b/examples/nrf52/nrf52840-dk/Cargo.toml
@@ -39,7 +39,6 @@ overflow-checks = false
 [patch.crates-io]
 embassy = { git = "https://github.com/embassy-rs/embassy.git", rev = "3d6b8bd9832d5a29cab4aa21434663e6ea6f4488" }
 embassy-nrf = { git = "https://github.com/embassy-rs/embassy.git", rev = "3d6b8bd9832d5a29cab4aa21434663e6ea6f4488" }
-embassy-boot = { git = "https://github.com/embassy-rs/embassy.git", rev = "3d6b8bd9832d5a29cab4aa21434663e6ea6f4488" }
 embassy-hal-common = { git = "https://github.com/embassy-rs/embassy.git", rev = "3d6b8bd9832d5a29cab4aa21434663e6ea6f4488" }
 nrf-softdevice = { git = "https://github.com/embassy-rs/nrf-softdevice.git", rev = "ba31fc03d97facc54efb9456901abf02549a4209" }
 nrf-softdevice-s140 = { git = "https://github.com/embassy-rs/nrf-softdevice.git", rev = "ba31fc03d97facc54efb9456901abf02549a4209" }


### PR DESCRIPTION
Currently, the following warning is generated when building the ble-mesh
example:
```console
warning: Patch `embassy-boot v0.1.0 (https://github.com/embassy-rs/embassy.gitrev=3d6b8bd9832d5a29cab4aa21434663e6ea6f4488#3d6b8bd9)` was not used in the crate graph.
```
I think this dependency is used by the bootloader-dfu example which has
this dependency in its Cargo.toml, so it seems safe to remove it from
the shared parent Cargo.toml.