### PR TITLE
Suppress unsued imports in model/mod.rs

### DIFF
--- a/device/src/drivers/ble/mesh/model/mod.rs
+++ b/device/src/drivers/ble/mesh/model/mod.rs
@@ -1,7 +1,9 @@
 use crate::drivers::ble::mesh::composition::CompanyIdentifier;
+#[allow(unused_imports)]
 use crate::drivers::ble::mesh::model::foundation::configuration::{
     CONFIGURATION_CLIENT, CONFIGURATION_SERVER,
 };
+#[allow(unused_imports)]
 use crate::drivers::ble::mesh::model::generic::{
     battery::{GENERIC_BATTERY_CLIENT, GENERIC_BATTERY_SERVER},
     onoff::{GENERIC_ONOFF_CLIENT, GENERIC_ONOFF_SERVER},


### PR DESCRIPTION
Currently, the following warnings are generated:
```console
warning: unused imports: `CONFIGURATION_CLIENT`, `CONFIGURATION_SERVER`
 --> device/src/drivers/ble/mesh/model/mod.rs:3:5
  |
3 |     CONFIGURATION_CLIENT, CONFIGURATION_SERVER,
  |     ^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: unused imports: `GENERIC_BATTERY_CLIENT`, `GENERIC_BATTERY_SERVER`, `GENERIC_ONOFF_CLIENT`, `GENERIC_ONOFF_SERVER`
 --> device/src/drivers/ble/mesh/model/mod.rs:6:15
  |
6 |     battery::{GENERIC_BATTERY_CLIENT, GENERIC_BATTERY_SERVER},
  |               ^^^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^
7 |     onoff::{GENERIC_ONOFF_CLIENT, GENERIC_ONOFF_SERVER},
  |             ^^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^

warning: `drogue-device` (lib) generated 2 warnings
```
This commit add an attribute to allow these unused imports.