### PR TITLE
Split pipeline into relevant halves with an inner enum.

### DIFF
--- a/device/src/drivers/ble/mesh/driver/elements/mod.rs
+++ b/device/src/drivers/ble/mesh/driver/elements/mod.rs
@@ -85,7 +85,6 @@ pub trait ElementContext {
     fn address(&self) -> Option<UnicastAddress>;
 }
 
-// todo: make primary significantly less special
 pub trait PrimaryElementContext: ElementContext {
     type NodeResetFuture<'m>: Future<Output = ()>
     where

--- a/device/src/drivers/ble/mesh/driver/mod.rs
+++ b/device/src/drivers/ble/mesh/driver/mod.rs
@@ -11,6 +11,8 @@ mod pipeline;
 
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum DeviceError {
+    PipelineNotConfigured,
+    AlreadyProvisioned,
     CryptoError(&'static str),
     Storage,
     StorageInitialization,

--- a/device/src/drivers/ble/mesh/driver/node/context.rs
+++ b/device/src/drivers/ble/mesh/driver/node/context.rs
@@ -401,7 +401,6 @@ where
     }
 
     fn address(&self) -> Option<UnicastAddress> {
-        // todo element-specific addresses
         if let Some(networks) = self.configuration_manager.configuration().network() {
             Some(*networks.unicast_address())
         } else {

--- a/device/src/drivers/ble/mesh/driver/node/mod.rs
+++ b/device/src/drivers/ble/mesh/driver/node/mod.rs
@@ -134,6 +134,7 @@ impl<'a> OutboundPublishChannel<'a> {
 }
 // --
 
+#[derive(Copy, Clone, PartialEq)]
 pub enum State {
     Unprovisioned,
     Provisioning,
@@ -360,6 +361,8 @@ where
             self.connect_elements();
         }
 
+        self.pipeline.borrow_mut().state(self.state);
+
         loop {
             let result = match self.state {
                 State::Unprovisioned => self.loop_unprovisioned().await,
@@ -376,7 +379,10 @@ where
                                 self.connect_elements()
                             }
                         }
-                        self.state = next_state;
+                        if next_state != self.state {
+                            self.pipeline.borrow_mut().state(self.state);
+                            self.state = next_state;
+                        }
                     }
                 }
                 Err(error) => {

--- a/device/src/drivers/ble/mesh/driver/pipeline/mesh.rs
+++ b/device/src/drivers/ble/mesh/driver/pipeline/mesh.rs
@@ -76,12 +76,4 @@ impl Mesh {
             Ok(None)
         }
     }
-
-    pub async fn process_outbound<C: MeshContext>(
-        &mut self,
-        ctx: &C,
-        pdu: advertising::AdvertisingPDU,
-    ) -> Result<(), DeviceError> {
-        ctx.transmit_advertising_pdu(pdu).await
-    }
 }

--- a/device/src/drivers/ble/mesh/driver/pipeline/mod.rs
+++ b/device/src/drivers/ble/mesh/driver/pipeline/mod.rs
@@ -14,6 +14,8 @@ use crate::drivers::ble::mesh::driver::pipeline::unprovisioned::provisioning_bea
 use crate::drivers::ble::mesh::driver::DeviceError;
 use crate::drivers::ble::mesh::generic_provisioning::Reason;
 use crate::drivers::ble::mesh::pdu::access::AccessMessage;
+use crate::drivers::ble::mesh::pdu::bearer::advertising::AdvertisingPDU;
+use crate::drivers::ble::mesh::pdu::network::ObfuscatedAndEncryptedNetworkPDU;
 use crate::drivers::ble::mesh::provisioning::Capabilities;
 use futures::{join, pin_mut};
 
@@ -25,98 +27,101 @@ pub trait PipelineContext: UnprovisionedContext + ProvisionedContext {}
 
 pub struct Pipeline {
     mesh: Mesh,
-    // unprovisioned pipeline
-    provisioning_bearer: ProvisioningBearer,
-    provisionable: Provisionable,
-    // provisioned pipeline
-    authentication: Authentication,
-    relay: Relay,
-    lower: Lower,
-    upper: Upper,
+    capabilities: Capabilities,
+    inner: PipelineInner,
 }
 
-impl Pipeline {
-    pub fn new(capabilities: Capabilities) -> Self {
-        Self {
-            mesh: Default::default(),
-            provisioning_bearer: Default::default(),
-            provisionable: Provisionable::new(capabilities),
-            //
-            authentication: Default::default(),
-            relay: Default::default(),
-            lower: Default::default(),
-            upper: Default::default(),
+enum PipelineInner {
+    Unconfigured,
+    Unprovisioned(UnprovisionedPipeline),
+    Provisioned(ProvisionedPipeline),
+}
+
+impl PipelineInner {
+    async fn process_inbound<C: PipelineContext>(
+        &mut self,
+        ctx: &C,
+        message: &mut MeshData,
+    ) -> Result<Option<State>, DeviceError> {
+        match self {
+            PipelineInner::Unconfigured => Ok(None),
+            PipelineInner::Unprovisioned(inner) => {
+                if let MeshData::Provisioning(pdu) = message {
+                    inner.process_inbound(ctx, pdu).await
+                } else {
+                    Ok(None)
+                }
+            }
+            PipelineInner::Provisioned(inner) => {
+                if let MeshData::Network(pdu) = message {
+                    inner.process_inbound(ctx, pdu).await
+                } else {
+                    Ok(None)
+                }
+            }
         }
     }
 
-    pub async fn process_inbound<C: PipelineContext>(
+    async fn process_outbound<C: PipelineContext>(
         &mut self,
         ctx: &C,
-        data: &[u8],
+        message: &AccessMessage,
+    ) -> Result<(), DeviceError> {
+        match self {
+            PipelineInner::Unconfigured => Err(DeviceError::NotProvisioned),
+            PipelineInner::Unprovisioned(_) => Err(DeviceError::NotProvisioned),
+            PipelineInner::Provisioned(inner) => inner.process_outbound(ctx, message).await,
+        }
+    }
+
+    pub async fn try_retransmit<C: PipelineContext>(&mut self, ctx: &C) -> Result<(), DeviceError> {
+        match self {
+            PipelineInner::Unconfigured => Err(DeviceError::PipelineNotConfigured),
+            PipelineInner::Unprovisioned(inner) => inner.try_retransmit(ctx).await,
+            PipelineInner::Provisioned(_) => Err(DeviceError::AlreadyProvisioned),
+        }
+    }
+}
+
+struct UnprovisionedPipeline {
+    provisioning_bearer: ProvisioningBearer,
+    provisionable: Provisionable,
+}
+
+impl UnprovisionedPipeline {
+    fn new(capabilities: Capabilities) -> Self {
+        Self {
+            provisioning_bearer: Default::default(),
+            provisionable: Provisionable::new(capabilities),
+        }
+    }
+
+    async fn process_inbound<C: PipelineContext>(
+        &mut self,
+        ctx: &C,
+        pdu: &AdvertisingPDU,
     ) -> Result<Option<State>, DeviceError> {
-        if let Some(result) = self.mesh.process_inbound(ctx, &data)? {
-            match result {
-                MeshData::Provisioning(pdu) => {
-                    if let Some(message) =
-                        self.provisioning_bearer.process_inbound(ctx, pdu).await?
+        if let Some(message) = self.provisioning_bearer.process_inbound(ctx, pdu).await? {
+            match message {
+                BearerMessage::ProvisioningPDU(provisioning_pdu) => {
+                    if let Some(outbound) = self
+                        .provisionable
+                        .process_inbound(ctx, provisioning_pdu)
+                        .await?
                     {
-                        match message {
-                            BearerMessage::ProvisioningPDU(provisioning_pdu) => {
-                                if let Some(outbound) = self
-                                    .provisionable
-                                    .process_inbound(ctx, provisioning_pdu)
-                                    .await?
-                                {
-                                    for pdu in
-                                        self.provisioning_bearer.process_outbound(outbound).await?
-                                    {
-                                        self.mesh.process_outbound(ctx, pdu).await?;
-                                    }
-                                }
-                                Ok(Some(State::Provisioning))
-                            }
-                            BearerMessage::Close(reason) => {
-                                self.provisioning_bearer.reset();
-                                self.provisionable.reset();
-                                match reason {
-                                    Reason::Success => Ok(Some(State::Provisioned)),
-                                    _ => Ok(Some(State::Unprovisioned)),
-                                }
-                            }
+                        for pdu in self.provisioning_bearer.process_outbound(outbound).await? {
+                            ctx.transmit_advertising_pdu(pdu).await?;
                         }
-                    } else {
-                        Ok(None)
                     }
+                    Ok(Some(State::Provisioning))
                 }
-                MeshData::Network(pdu) => {
-                    if let Some(inboud_pdu) = self.authentication.process_inbound(ctx, pdu)? {
-                        let (ack, pdu) = self.lower.process_inbound(ctx, &inboud_pdu).await?;
-
-                        if let Some(pdu) = pdu {
-                            if let Some(message) = self.upper.process_inbound(ctx, pdu)? {
-                                ctx.dispatch_access(&message).await?;
-                            }
-                        }
-
-                        if let Some(ack) = ack {
-                            if let Some(ack) = self.authentication.process_outbound(ctx, &ack)? {
-                                // don't fail if we fail to transmit the ack.
-                                ctx.transmit_mesh_pdu(&ack).await.ok();
-                            }
-                        }
-
-                        // Relaying is independent from processing it locally
-                        if let Some(outbound) = self.relay.process_inbound(ctx, &inboud_pdu)? {
-                            // don't fail if we fail to encrypt a relay.
-                            if let Ok(Some(outbound)) =
-                                self.authentication.process_outbound(ctx, &outbound)
-                            {
-                                // don't fail if we fail to retransmit.
-                                ctx.transmit_mesh_pdu(&outbound).await.ok();
-                            }
-                        }
+                BearerMessage::Close(reason) => {
+                    self.provisioning_bearer.reset();
+                    self.provisionable.reset();
+                    match reason {
+                        Reason::Success => Ok(Some(State::Provisioned)),
+                        _ => Ok(Some(State::Unprovisioned)),
                     }
-                    Ok(None)
                 }
             }
         } else {
@@ -124,7 +129,62 @@ impl Pipeline {
         }
     }
 
-    pub async fn process_outbound<C: PipelineContext>(
+    async fn try_retransmit<C: PipelineContext>(&mut self, ctx: &C) -> Result<(), DeviceError> {
+        self.provisioning_bearer.try_retransmit(ctx).await
+    }
+}
+
+struct ProvisionedPipeline {
+    authentication: Authentication,
+    relay: Relay,
+    lower: Lower,
+    upper: Upper,
+}
+
+impl ProvisionedPipeline {
+    fn new() -> Self {
+        Self {
+            authentication: Default::default(),
+            relay: Default::default(),
+            lower: Default::default(),
+            upper: Default::default(),
+        }
+    }
+
+    async fn process_inbound<C: PipelineContext>(
+        &mut self,
+        ctx: &C,
+        pdu: &mut ObfuscatedAndEncryptedNetworkPDU,
+    ) -> Result<Option<State>, DeviceError> {
+        if let Some(inboud_pdu) = self.authentication.process_inbound(ctx, pdu)? {
+            let (ack, pdu) = self.lower.process_inbound(ctx, &inboud_pdu).await?;
+
+            if let Some(pdu) = pdu {
+                if let Some(message) = self.upper.process_inbound(ctx, pdu)? {
+                    ctx.dispatch_access(&message).await?;
+                }
+            }
+
+            if let Some(ack) = ack {
+                if let Some(ack) = self.authentication.process_outbound(ctx, &ack)? {
+                    // don't fail if we fail to transmit the ack.
+                    ctx.transmit_mesh_pdu(&ack).await.ok();
+                }
+            }
+
+            // Relaying is independent from processing it locally
+            if let Some(outbound) = self.relay.process_inbound(ctx, &inboud_pdu)? {
+                // don't fail if we fail to encrypt a relay.
+                if let Ok(Some(outbound)) = self.authentication.process_outbound(ctx, &outbound) {
+                    // don't fail if we fail to retransmit.
+                    ctx.transmit_mesh_pdu(&outbound).await.ok();
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    async fn process_outbound<C: PipelineContext>(
         &mut self,
         ctx: &C,
         message: &AccessMessage,
@@ -165,8 +225,52 @@ impl Pipeline {
             (Err(e), _) => Err(e),
         }
     }
+}
+
+impl Pipeline {
+    pub fn new(capabilities: Capabilities) -> Self {
+        Self {
+            mesh: Default::default(),
+            capabilities,
+            inner: PipelineInner::Unconfigured,
+        }
+    }
+
+    pub(crate) fn state(&mut self, state: State) {
+        match state {
+            State::Unprovisioned => {
+                self.inner = PipelineInner::Unprovisioned(UnprovisionedPipeline::new(
+                    self.capabilities.clone(),
+                ))
+            }
+            State::Provisioned => {
+                self.inner = PipelineInner::Provisioned(ProvisionedPipeline::new())
+            }
+            _ => {}
+        }
+    }
+
+    pub async fn process_inbound<C: PipelineContext>(
+        &mut self,
+        ctx: &C,
+        data: &[u8],
+    ) -> Result<Option<State>, DeviceError> {
+        if let Some(mut result) = self.mesh.process_inbound(ctx, &data)? {
+            self.inner.process_inbound(ctx, &mut result).await
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub async fn process_outbound<C: PipelineContext>(
+        &mut self,
+        ctx: &C,
+        message: &AccessMessage,
+    ) -> Result<(), DeviceError> {
+        self.inner.process_outbound(ctx, message).await
+    }
 
     pub async fn try_retransmit<C: PipelineContext>(&mut self, ctx: &C) -> Result<(), DeviceError> {
-        self.provisioning_bearer.try_retransmit(ctx).await
+        self.inner.try_retransmit(ctx).await
     }
 }

--- a/device/src/drivers/ble/mesh/driver/pipeline/provisioned/network/authentication.rs
+++ b/device/src/drivers/ble/mesh/driver/pipeline/provisioned/network/authentication.rs
@@ -35,7 +35,7 @@ impl Authentication {
     pub fn process_inbound<C: AuthenticationContext>(
         &mut self,
         ctx: &C,
-        mut pdu: ObfuscatedAndEncryptedNetworkPDU,
+        pdu: &mut ObfuscatedAndEncryptedNetworkPDU,
     ) -> Result<Option<CleartextNetworkPDU>, DeviceError> {
         if let Some(iv_index) = ctx.iv_index() {
             let privacy_plaintext = Self::privacy_plaintext(iv_index, &pdu.encrypted_and_mic);

--- a/device/src/drivers/ble/mesh/driver/pipeline/unprovisioned/segmentation/mod.rs
+++ b/device/src/drivers/ble/mesh/driver/pipeline/unprovisioned/segmentation/mod.rs
@@ -20,9 +20,9 @@ impl Default for Segmentation {
 }
 
 impl Segmentation {
-    pub async fn process_inbound(
+    pub fn process_inbound(
         &mut self,
-        pdu: GenericProvisioningPDU,
+        pdu: &GenericProvisioningPDU,
     ) -> Result<Option<ProvisioningPDU>, DeviceError> {
         match pdu {
             GenericProvisioningPDU::TransactionStart(transaction_start) => {

--- a/device/src/drivers/ble/mesh/generic_provisioning.rs
+++ b/device/src/drivers/ble/mesh/generic_provisioning.rs
@@ -196,6 +196,7 @@ impl ProvisioningBearerControl {
     }
 }
 
+#[derive(Copy, Clone)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub enum Reason {
     Success = 0x00,


### PR DESCRIPTION
Remove gratuitous `async` markers where not necessary.