### PR TITLE
Suppress build warnings

### DIFF
--- a/examples/nrf52/microbit/compass/Cargo.lock
+++ b/examples/nrf52/microbit/compass/Cargo.lock
@@ -950,13 +950,3 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
-
-[[patch.unused]]
-name = "nrf-softdevice"
-version = "0.1.0"
-source = "git+https://github.com/embassy-rs/nrf-softdevice.git?rev=c584deaf9d9e941f18457934a4a463e078f380ec#c584deaf9d9e941f18457934a4a463e078f380ec"
-
-[[patch.unused]]
-name = "nrf-softdevice-s113"
-version = "0.1.1"
-source = "git+https://github.com/embassy-rs/nrf-softdevice.git?rev=c584deaf9d9e941f18457934a4a463e078f380ec#c584deaf9d9e941f18457934a4a463e078f380ec"

--- a/examples/nrf52/microbit/compass/Cargo.toml
+++ b/examples/nrf52/microbit/compass/Cargo.toml
@@ -63,8 +63,6 @@ overflow-checks = false
 [patch.crates-io]
 embassy = { git = "https://github.com/embassy-rs/embassy.git", rev = "da9c0efaad594b48cfcdf641d353133d14cf98fe" }
 embassy-nrf = { git = "https://github.com/embassy-rs/embassy.git", rev = "da9c0efaad594b48cfcdf641d353133d14cf98fe" }
-nrf-softdevice = { git = "https://github.com/embassy-rs/nrf-softdevice.git", rev = "c584deaf9d9e941f18457934a4a463e078f380ec" }
-nrf-softdevice-s113 = { git = "https://github.com/embassy-rs/nrf-softdevice.git", rev = "c584deaf9d9e941f18457934a4a463e078f380ec" }
 
 #embassy = { path = "../../../../../embassy/embassy" }
 #embassy-nrf = { path = "../../../../../embassy/embassy-nrf" }

--- a/examples/nrf52/microbit/jukebox/Cargo.lock
+++ b/examples/nrf52/microbit/jukebox/Cargo.lock
@@ -932,13 +932,3 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
-
-[[patch.unused]]
-name = "nrf-softdevice"
-version = "0.1.0"
-source = "git+https://github.com/embassy-rs/nrf-softdevice.git?rev=c584deaf9d9e941f18457934a4a463e078f380ec#c584deaf9d9e941f18457934a4a463e078f380ec"
-
-[[patch.unused]]
-name = "nrf-softdevice-s113"
-version = "0.1.1"
-source = "git+https://github.com/embassy-rs/nrf-softdevice.git?rev=c584deaf9d9e941f18457934a4a463e078f380ec#c584deaf9d9e941f18457934a4a463e078f380ec"

--- a/examples/nrf52/microbit/jukebox/Cargo.toml
+++ b/examples/nrf52/microbit/jukebox/Cargo.toml
@@ -62,8 +62,6 @@ overflow-checks = false
 [patch.crates-io]
 embassy = { git = "https://github.com/embassy-rs/embassy.git", rev = "da9c0efaad594b48cfcdf641d353133d14cf98fe" }
 embassy-nrf = { git = "https://github.com/embassy-rs/embassy.git", rev = "da9c0efaad594b48cfcdf641d353133d14cf98fe" }
-nrf-softdevice = { git = "https://github.com/embassy-rs/nrf-softdevice.git", rev = "c584deaf9d9e941f18457934a4a463e078f380ec" }
-nrf-softdevice-s113 = { git = "https://github.com/embassy-rs/nrf-softdevice.git", rev = "c584deaf9d9e941f18457934a4a463e078f380ec" }
 
 #embassy = { path = "../../../../../embassy/embassy" }
 #embassy-nrf = { path = "../../../../../embassy/embassy-nrf" }

--- a/examples/nrf52/nrf52840-dk/.cargo/config.toml
+++ b/examples/nrf52/nrf52840-dk/.cargo/config.toml
@@ -1,5 +1,4 @@
 [unstable]
-namespaced-features = true
 build-std = ["core"]
 build-std-features = ["panic_immediate_abort"]
 


### PR DESCRIPTION
This commit attempts to fix a couple of build warnings that are
currently being generated:
```console
warning: unused config key `unstable.namespaced-features` in
`/drougue/drogue-device/examples/nrf52/nrf52840-dk/.cargo/config.toml`

warning: Patch `nrf-softdevice v0.1.0
(https://github.com/embassy-rs/nrf-softdevice.git?rev=\c584deaf9d9e941f18457934a4a463e078f380ec#c584deaf)` was not used in the crate graph.
```