### PR TITLE
Update embassy commit rev for neopixel example

### DIFF
--- a/examples/nrf52/adafruit-nrf-feather/neopixel/Cargo.lock
+++ b/examples/nrf52/adafruit-nrf-feather/neopixel/Cargo.lock
@@ -11,7 +11,7 @@ dependencies = [
  "defmt",
  "defmt-rtt",
  "drogue-device",
- "embassy 0.1.0 (git+https://github.com/embassy-rs/embassy.git?rev=6a3b3ca755073f73b24fad89a109fba7132d1312)",
+ "embassy 0.1.0 (git+https://github.com/embassy-rs/embassy.git?rev=da9c0efaad594b48cfcdf641d353133d14cf98fe)",
  "embassy-nrf",
  "futures",
  "heapless",
@@ -255,7 +255,7 @@ dependencies = [
  "critical-section",
  "defmt",
  "drogue-device-macros",
- "embassy 0.1.0 (git+https://github.com/embassy-rs/embassy.git?rev=6a3b3ca755073f73b24fad89a109fba7132d1312)",
+ "embassy 0.1.0 (git+https://github.com/embassy-rs/embassy.git?rev=da9c0efaad594b48cfcdf641d353133d14cf98fe)",
  "embassy-hal-common 0.1.0 (git+https://github.com/embassy-rs/embassy)",
  "embassy-nrf",
  "embedded-hal 0.2.7",
@@ -283,14 +283,14 @@ dependencies = [
 [[package]]
 name = "embassy"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=6a3b3ca755073f73b24fad89a109fba7132d1312#6a3b3ca755073f73b24fad89a109fba7132d1312"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=da9c0efaad594b48cfcdf641d353133d14cf98fe#da9c0efaad594b48cfcdf641d353133d14cf98fe"
 dependencies = [
  "atomic-polyfill",
  "cfg-if",
  "cortex-m",
  "critical-section",
  "defmt",
- "embassy-macros 0.1.0 (git+https://github.com/embassy-rs/embassy.git?rev=6a3b3ca755073f73b24fad89a109fba7132d1312)",
+ "embassy-macros 0.1.0 (git+https://github.com/embassy-rs/embassy.git?rev=da9c0efaad594b48cfcdf641d353133d14cf98fe)",
  "embedded-hal 0.2.7",
  "embedded-hal-async",
  "futures",
@@ -317,10 +317,10 @@ dependencies = [
 [[package]]
 name = "embassy-hal-common"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=6a3b3ca755073f73b24fad89a109fba7132d1312#6a3b3ca755073f73b24fad89a109fba7132d1312"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=da9c0efaad594b48cfcdf641d353133d14cf98fe#da9c0efaad594b48cfcdf641d353133d14cf98fe"
 dependencies = [
  "cortex-m",
- "embassy 0.1.0 (git+https://github.com/embassy-rs/embassy.git?rev=6a3b3ca755073f73b24fad89a109fba7132d1312)",
+ "embassy 0.1.0 (git+https://github.com/embassy-rs/embassy.git?rev=da9c0efaad594b48cfcdf641d353133d14cf98fe)",
  "num-traits 0.2.14",
  "usb-device",
 ]
@@ -339,7 +339,7 @@ dependencies = [
 [[package]]
 name = "embassy-macros"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=6a3b3ca755073f73b24fad89a109fba7132d1312#6a3b3ca755073f73b24fad89a109fba7132d1312"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=da9c0efaad594b48cfcdf641d353133d14cf98fe#da9c0efaad594b48cfcdf641d353133d14cf98fe"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -361,16 +361,16 @@ dependencies = [
 [[package]]
 name = "embassy-nrf"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?rev=6a3b3ca755073f73b24fad89a109fba7132d1312#6a3b3ca755073f73b24fad89a109fba7132d1312"
+source = "git+https://github.com/embassy-rs/embassy.git?rev=da9c0efaad594b48cfcdf641d353133d14cf98fe#da9c0efaad594b48cfcdf641d353133d14cf98fe"
 dependencies = [
  "cfg-if",
  "cortex-m",
  "cortex-m-rt",
  "critical-section",
  "defmt",
- "embassy 0.1.0 (git+https://github.com/embassy-rs/embassy.git?rev=6a3b3ca755073f73b24fad89a109fba7132d1312)",
- "embassy-hal-common 0.1.0 (git+https://github.com/embassy-rs/embassy.git?rev=6a3b3ca755073f73b24fad89a109fba7132d1312)",
- "embassy-macros 0.1.0 (git+https://github.com/embassy-rs/embassy.git?rev=6a3b3ca755073f73b24fad89a109fba7132d1312)",
+ "embassy 0.1.0 (git+https://github.com/embassy-rs/embassy.git?rev=da9c0efaad594b48cfcdf641d353133d14cf98fe)",
+ "embassy-hal-common 0.1.0 (git+https://github.com/embassy-rs/embassy.git?rev=da9c0efaad594b48cfcdf641d353133d14cf98fe)",
+ "embassy-macros 0.1.0 (git+https://github.com/embassy-rs/embassy.git?rev=da9c0efaad594b48cfcdf641d353133d14cf98fe)",
  "embedded-dma",
  "embedded-hal 0.2.7",
  "embedded-hal 1.0.0-alpha.7",

--- a/examples/nrf52/adafruit-nrf-feather/neopixel/Cargo.toml
+++ b/examples/nrf52/adafruit-nrf-feather/neopixel/Cargo.toml
@@ -69,9 +69,9 @@ opt-level = 0
 overflow-checks = false
 
 [patch.crates-io]
-embassy = { git = "https://github.com/embassy-rs/embassy.git", rev = "6a3b3ca755073f73b24fad89a109fba7132d1312" }
-embassy-nrf = { git = "https://github.com/embassy-rs/embassy.git", rev = "6a3b3ca755073f73b24fad89a109fba7132d1312" }
-embassy-hal-common = { git = "https://github.com/embassy-rs/embassy.git", rev = "6a3b3ca755073f73b24fad89a109fba7132d1312" }
+embassy = { git = "https://github.com/embassy-rs/embassy.git", rev = "da9c0efaad594b48cfcdf641d353133d14cf98fe" }
+embassy-nrf = { git = "https://github.com/embassy-rs/embassy.git", rev = "da9c0efaad594b48cfcdf641d353133d14cf98fe" }
+embassy-hal-common = { git = "https://github.com/embassy-rs/embassy.git", rev = "da9c0efaad594b48cfcdf641d353133d14cf98fe" }
 
 #embassy = { path = "../../../../../embassy/embassy" }
 #embassy-nrf = { path = "../../../../../embassy/embassy-nrf" }


### PR DESCRIPTION
Currently, the following build error is generated when running cargo
build in examples/nrf52/adafruit-nrf-feather/neopixel:
```console
Building /drogue-device/examples/nrf52/adafruit-nrf-feather/neopixel
$ cargo build --release
    Updating git repository `https://github.com/embassy-rs/embassy.git`
error: failed to resolve patches for `https://github.com/rust-lang/crates.io-index`

Caused by:
  failed to load source for dependency `embassy`

Caused by:
  Unable to update https://github.com/embassy-rs/embassy.git?rev=6a3b3ca755073f73b24fad89a109fba7132d1312#6a3b3ca7

Caused by:
  object not found - no match for id (6a3b3ca755073f73b24fad89a109fba7132d1312); class=Odb (9); code=NotFound (-3)
Error: command `cargo build --release` failed, exit status: 101
```
I've not looked into why this commit is no longer available, but
updating it to the same revision that other examples uses, allowed the
example to build (and also allowed 'xtask ci' to complete successfully).