### PR TITLE
stm32wl55 bsp update and Button working

### DIFF
--- a/device/src/bsp/boards/stm32wl/nucleo_wl55.rs
+++ b/device/src/bsp/boards/stm32wl/nucleo_wl55.rs
@@ -8,7 +8,7 @@ use embassy_stm32::gpio::Pin;
 use embassy_stm32::gpio::{Input, Level, Output, Pull, Speed};
 use embassy_stm32::interrupt;
 use embassy_stm32::pac;
-use embassy_stm32::peripherals::{PA0, PB11, PB15, PB9, RNG};
+use embassy_stm32::peripherals::{PA0, PA1, PB11, PB15, PB9, PC6, RNG};
 use embassy_stm32::subghz::*;
 
 pub type PinLedBlue = Output<'static, PB15>;
@@ -20,8 +20,14 @@ pub type LedGreen = Led<PinLedGreen, ActiveHigh>;
 pub type PinLedYellow = Output<'static, PB11>;
 pub type LedYellow = Led<PinLedYellow, ActiveHigh>;
 
-pub type PinUserButton = Input<'static, PA0>;
-pub type UserButton = Button<ExtiInput<'static, PA0>>;
+pub type PinUserButtonB1 = Input<'static, PA0>;
+pub type UserButtonB1 = Button<ExtiInput<'static, PA0>>;
+
+pub type PinUserButtonB2 = Input<'static, PA1>;
+pub type UserButtonB2 = Button<ExtiInput<'static, PA1>>;
+
+pub type PinUserButtonB3 = Input<'static, PC6>;
+pub type UserButtonB3 = Button<ExtiInput<'static, PC6>>;
 
 pub type Radio = SubGhzRadio<'static>;
 pub type Rng = embassy_stm32::rng::Rng<'static, RNG>;
@@ -30,7 +36,9 @@ pub struct NucleoWl55 {
     pub led_blue: LedBlue,
     pub led_green: LedGreen,
     pub led_yellow: LedYellow,
-    pub user_button: UserButton,
+    pub user_button_b1: UserButtonB1,
+    pub user_button_b2: UserButtonB2,
+    pub user_button_b3: UserButtonB3,
     pub rng: Rng,
     pub radio: Radio,
 }
@@ -59,8 +67,12 @@ impl Board for NucleoWl55 {
         let led_green = Led::new(Output::new(p.PB9, Level::Low, Speed::Low));
         let led_yellow = Led::new(Output::new(p.PB11, Level::Low, Speed::Low));
 
-        let button = Input::new(p.PA0, Pull::Up);
-        let user_button = Button::new(ExtiInput::new(button, p.EXTI0));
+        let button_b1 = Input::new(p.PA0, Pull::Up);
+        let user_button_b1 = Button::new(ExtiInput::new(button_b1, p.EXTI0));
+        let button_b2 = Input::new(p.PA1, Pull::Up);
+        let user_button_b2 = Button::new(ExtiInput::new(button_b2, p.EXTI1));
+        let button_b3 = Input::new(p.PC6, Pull::Up);
+        let user_button_b3 = Button::new(ExtiInput::new(button_b3, p.EXTI6));
 
         let ctrl1 = Output::new(p.PC3.degrade(), Level::High, Speed::High);
         let ctrl2 = Output::new(p.PC4.degrade(), Level::High, Speed::High);
@@ -77,7 +89,9 @@ impl Board for NucleoWl55 {
             led_blue,
             led_green,
             led_yellow,
-            user_button,
+            user_button_b1,
+            user_button_b2,
+            user_button_b3,
             rng,
             radio,
         }

--- a/device/src/bsp/boards/stm32wl/nucleo_wl55.rs
+++ b/device/src/bsp/boards/stm32wl/nucleo_wl55.rs
@@ -12,13 +12,13 @@ use embassy_stm32::peripherals::{PA0, PA1, PB11, PB15, PB9, PC6, RNG};
 use embassy_stm32::subghz::*;
 
 pub type PinLedBlue = Output<'static, PB15>;
-pub type LedBlue = Led<PinLedBlue, ActiveHigh>;
+pub type LedBlue = Led<PinLedBlue, ActiveLow>;
 
 pub type PinLedGreen = Output<'static, PB9>;
-pub type LedGreen = Led<PinLedGreen, ActiveHigh>;
+pub type LedGreen = Led<PinLedGreen, ActiveLow>;
 
 pub type PinLedYellow = Output<'static, PB11>;
-pub type LedYellow = Led<PinLedYellow, ActiveHigh>;
+pub type LedYellow = Led<PinLedYellow, ActiveLow>;
 
 pub type PinUserButtonB1 = Input<'static, PA0>;
 pub type UserButtonB1 = Button<ExtiInput<'static, PA0>>;

--- a/device/src/drivers/button.rs
+++ b/device/src/drivers/button.rs
@@ -32,7 +32,7 @@ impl Active for ActiveLow {
     }
 }
 
-pub struct Button<P, ACTIVE = ActiveLow>
+pub struct Button<P, ACTIVE = ActiveHigh>
 where
     P: Wait + InputPin + 'static,
     ACTIVE: Active,

--- a/device/src/drivers/button.rs
+++ b/device/src/drivers/button.rs
@@ -32,7 +32,7 @@ impl Active for ActiveLow {
     }
 }
 
-pub struct Button<P, ACTIVE = ActiveHigh>
+pub struct Button<P, ACTIVE = ActiveLow>
 where
     P: Wait + InputPin + 'static,
     ACTIVE: Active,


### PR DESCRIPTION
stm32wl55 has three buttons , two missing buttons were added

button press was inverted before.
 ActiveLow ensures when a button is pressed, it is a high signal.