### PR TITLE
Enable using AccessMessage outside of the crate

### DIFF
--- a/device/src/drivers/ble/mesh/driver/node/mod.rs
+++ b/device/src/drivers/ble/mesh/driver/node/mod.rs
@@ -111,11 +111,11 @@ where
                     let model_key = publish.model_key();
                     let message = AccessMessage {
                         ttl: publication.publish_ttl,
-                        network_key: NetworkKeyHandle::from(network),
+                        network_key: Some(NetworkKeyHandle::from(network)),
                         // todo: ivi isn't always zero.
-                        ivi: 0,
-                        nid: network.nid,
-                        akf: true,
+                        ivi: Some(0),
+                        nid: Some(network.nid),
+                        akf: Some(true),
                         aid: app_key_details.aid,
                         src: publish.element_address,
                         dst: publication.publish_address,

--- a/device/src/drivers/ble/mesh/driver/pipeline/provisioned/upper/mod.rs
+++ b/device/src/drivers/ble/mesh/driver/pipeline/provisioned/upper/mod.rs
@@ -65,10 +65,10 @@ impl Upper {
         message.emit(&mut payload)?;
         Ok(Some(UpperPDU::Access(UpperAccess {
             ttl: message.ttl,
-            network_key: message.network_key,
-            ivi: message.ivi,
-            nid: message.nid,
-            akf: message.akf,
+            network_key: message.network_key.unwrap_or_default(),
+            ivi: message.ivi.unwrap_or_default(),
+            nid: message.nid.unwrap_or_default(),
+            akf: message.akf.unwrap_or_default(),
             aid: message.aid,
             src: message.src,
             dst: message.dst,

--- a/device/src/drivers/ble/mesh/pdu/access.rs
+++ b/device/src/drivers/ble/mesh/pdu/access.rs
@@ -12,14 +12,14 @@ use heapless::Vec;
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct AccessMessage {
     pub ttl: Option<u8>,
-    pub(crate) network_key: NetworkKeyHandle,
-    pub(crate) ivi: u8,
-    pub(crate) nid: u8,
-    pub(crate) akf: bool,
-    pub(crate) aid: ApplicationKeyIdentifier,
-    pub(crate) src: UnicastAddress,
-    pub(crate) dst: Address,
-    pub(crate) payload: AccessPayload,
+    pub network_key: Option<NetworkKeyHandle>,
+    pub ivi: Option<u8>,
+    pub nid: Option<u8>,
+    pub akf: Option<bool>,
+    pub aid: ApplicationKeyIdentifier,
+    pub src: UnicastAddress,
+    pub dst: Address,
+    pub payload: AccessPayload,
 }
 
 #[allow(unused)]
@@ -40,15 +40,34 @@ impl AccessMessage {
     pub fn parse(access: &UpperAccess) -> Result<Self, ParseError> {
         Ok(Self {
             ttl: None,
-            network_key: access.network_key,
-            ivi: access.ivi,
-            nid: access.nid,
-            akf: access.akf,
+            network_key: Some(access.network_key),
+            ivi: Some(access.ivi),
+            nid: Some(access.nid),
+            akf: Some(access.akf),
             aid: access.aid,
             src: access.src,
             dst: access.dst,
             payload: AccessPayload::parse(&access.payload)?,
         })
+    }
+
+    pub fn new(
+        aid: ApplicationKeyIdentifier,
+        src: UnicastAddress,
+        dst: Address,
+        payload: AccessPayload,
+    ) -> Self {
+        Self {
+            ttl: None,
+            network_key: None,
+            ivi: None,
+            nid: None,
+            akf: None,
+            aid,
+            src,
+            dst,
+            payload,
+        }
     }
 
     pub fn emit<const N: usize>(&self, xmit: &mut Vec<u8, N>) -> Result<(), InsufficientBuffer> {


### PR DESCRIPTION
As ElementHandlers are using AccessMessage and I want to use the same abstractions in bluer, there has to be a way to create an AccessMessage outside of crate. I additionally marked some of the fields as optional as they are not used in this context. I'm still not sure if that's the right way to go (or should we maybe redesign the structs). Here's the example of how this is used

https://github.com/dejanb/bluer/blob/mesh/bluer/src/mesh/mod.rs#L74

Let me know if you have any thoughts on how to better implement this.