### PR TITLE
fix: convert files to asciidoc

### DIFF
--- a/examples/nrf52/adafruit-feather-nrf52840/bootloader/README.adoc
+++ b/examples/nrf52/adafruit-feather-nrf52840/bootloader/README.adoc
@@ -1,11 +1,11 @@
-# Bootloader for nRF 52840 with external flash capability
+= Bootloader for nRF 52840 with external flash capability
 
 The bootloader uses `embassy-boot` to interact with the flash.
 
-# Usage
+== Usage
 
 Flash the bootloader
 
-```
+----
 cargo flash --release --chip nRF52840_xxAA
-```
+----

--- a/examples/nrf52/microbit/bootloader/README.adoc
+++ b/examples/nrf52/microbit/bootloader/README.adoc
@@ -1,11 +1,11 @@
-# Bootloader for nRF with external flash capability
+= Bootloader for nRF with external flash capability
 
 The bootloader uses `embassy-boot` to interact with the flash.
 
-# Usage
+== Usage
 
 Flash the bootloader
 
-```
+----
 cargo flash --release --chip nRF52833_xxAA
-```
+----

--- a/examples/stm32l4/iot01a/bootloader/README.adoc
+++ b/examples/stm32l4/iot01a/bootloader/README.adoc
@@ -1,11 +1,11 @@
-# Bootloader for STM32
+= Bootloader for STM32
 
 The bootloader uses `embassy-boot` to interact with the flash.
 
-# Usage
+== Usage
 
 Flash the bootloader
 
-```
+----
 cargo flash --features --release --chip STM32L475VG
-```
+----

--- a/examples/stm32wl/nucleo-wl55/bootloader/README.adoc
+++ b/examples/stm32wl/nucleo-wl55/bootloader/README.adoc
@@ -1,11 +1,11 @@
-# Bootloader for STM32
+= Bootloader for STM32
 
 The bootloader uses `embassy-boot` to interact with the flash.
 
-# Usage
+== Usage
 
 Flash the bootloader
 
-```
+----
 cargo flash --features --release --chip STM32L475VG
-```
+----


### PR DESCRIPTION
These files are referenced as .adoc, but are actually .md. This is why the docs
fail to build (now).