### PR TITLE
Change bootloader name to nucleo-wl55-bootloader

### DIFF
--- a/examples/stm32wl/nucleo-wl55/Cargo.lock
+++ b/examples/stm32wl/nucleo-wl55/Cargo.lock
@@ -1290,23 +1290,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a257582fdcde896fd96463bf2d40eefea0580021c0712a0e2b028b60b47a837a"
 
 [[package]]
-name = "iot01a-bootloader"
-version = "0.1.0"
-dependencies = [
- "cfg-if",
- "cortex-m",
- "cortex-m-rt",
- "defmt",
- "defmt-rtt",
- "embassy-boot",
- "embassy-boot-stm32",
- "embassy-stm32",
- "embedded-storage",
- "embedded-storage-async",
- "static_cell",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1482,6 +1465,23 @@ checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "nucleo-wl55-bootloader"
+version = "0.1.0"
+dependencies = [
+ "cfg-if",
+ "cortex-m",
+ "cortex-m-rt",
+ "defmt",
+ "defmt-rtt",
+ "embassy-boot",
+ "embassy-boot-stm32",
+ "embassy-stm32",
+ "embedded-storage",
+ "embedded-storage-async",
+ "static_cell",
 ]
 
 [[package]]

--- a/examples/stm32wl/nucleo-wl55/bootloader/Cargo.toml
+++ b/examples/stm32wl/nucleo-wl55/bootloader/Cargo.toml
@@ -3,7 +3,7 @@ authors = [
     "Ulf Lilleengen <lulf@redhat.com>",
 ]
 edition = "2021"
-name = "iot01a-bootloader"
+name = "nucleo-wl55-bootloader"
 version = "0.1.0"
 description = "Bootloader for STM32L4 iot01a boards"
 


### PR DESCRIPTION
This commit changes the name of this crate to be
`nucleo-wl55-bootloader` instead of `iot01a-bootloader`.

The motivation for this change is that there another crate with the same name in `/examples/stm32l4/iot01a/bootloader`.
And when building the EclipseCon 2022 Hackaton firmware the following warning is generated:
```console
$ cargo b --release
warning: skipping duplicate package `iot01a-bootloader` found at `/.cargo/git/checkouts/drogue-device-5b9868033e74c452/05ef609/examples/stm32l4/iot01a/bootloader`
```
I've verified is by manually changing the name of the nucleo-wl55-bootloader in the git checkouts directory and the warning is gone. I looks like the dependency microbit-bsp is causing this and I'm guessing here that all of the Cargo.toml files are parsed for this dependency (git repo drogue-iot/drogue-device.git), and that the workspace in drogue-device is not used in this case.

----
Reproducer:
```console
$ cargo new microbit-dep && cd microbit-dep
```
Edit Cargo.toml:
```console
[package]
name = "microbit-dep"
version = "0.1.0"
edition = "2021"

[dependencies]
microbit-bsp = { git = "https://github.com/drogue-iot/drogue-device.git", rev = "05ef60945cc3736eb7bcba3f2fecb247279fdffa" }
```
Run the following command to see the warning:
```console
$ cargo fetch
    Updating git repository `https://github.com/drogue-iot/drogue-device.git`
warning: skipping duplicate package `iot01a-bootloader` found at `/home/danielbevenius/.cargo/git/checkouts/drogue-device-5b9868033e74c452/05ef609/examples/stm32l4/iot01a/bootloader`
```