### PR TITLE
feat: support uf2 firmware for pico

### DIFF
--- a/examples/rp2040/pico-w/Cargo.lock
+++ b/examples/rp2040/pico-w/Cargo.lock
@@ -580,7 +580,7 @@ dependencies = [
 [[package]]
 name = "embassy-boot"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?tag=embassy-time-v0.1.0#61560e740dea1b4c7ca036dafd66c834a1ff92e2"
+source = "git+https://github.com/embassy-rs/embassy?rev=5c52d6c2172ba76267fd79b74f406fc74a50744d#5c52d6c2172ba76267fd79b74f406fc74a50744d"
 dependencies = [
  "embassy-sync",
  "embedded-storage",
@@ -590,7 +590,7 @@ dependencies = [
 [[package]]
 name = "embassy-cortex-m"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?tag=embassy-time-v0.1.0#61560e740dea1b4c7ca036dafd66c834a1ff92e2"
+source = "git+https://github.com/embassy-rs/embassy?rev=5c52d6c2172ba76267fd79b74f406fc74a50744d#5c52d6c2172ba76267fd79b74f406fc74a50744d"
 dependencies = [
  "atomic-polyfill 1.0.1",
  "cfg-if",
@@ -605,7 +605,7 @@ dependencies = [
 [[package]]
 name = "embassy-embedded-hal"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?tag=embassy-time-v0.1.0#61560e740dea1b4c7ca036dafd66c834a1ff92e2"
+source = "git+https://github.com/embassy-rs/embassy?rev=5c52d6c2172ba76267fd79b74f406fc74a50744d#5c52d6c2172ba76267fd79b74f406fc74a50744d"
 dependencies = [
  "embassy-sync",
  "embedded-hal 0.2.7",
@@ -619,7 +619,7 @@ dependencies = [
 [[package]]
 name = "embassy-executor"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?tag=embassy-time-v0.1.0#61560e740dea1b4c7ca036dafd66c834a1ff92e2"
+source = "git+https://github.com/embassy-rs/embassy?rev=5c52d6c2172ba76267fd79b74f406fc74a50744d#5c52d6c2172ba76267fd79b74f406fc74a50744d"
 dependencies = [
  "atomic-polyfill 1.0.1",
  "cfg-if",
@@ -634,12 +634,12 @@ dependencies = [
 [[package]]
 name = "embassy-futures"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?tag=embassy-time-v0.1.0#61560e740dea1b4c7ca036dafd66c834a1ff92e2"
+source = "git+https://github.com/embassy-rs/embassy?rev=5c52d6c2172ba76267fd79b74f406fc74a50744d#5c52d6c2172ba76267fd79b74f406fc74a50744d"
 
 [[package]]
 name = "embassy-hal-common"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?tag=embassy-time-v0.1.0#61560e740dea1b4c7ca036dafd66c834a1ff92e2"
+source = "git+https://github.com/embassy-rs/embassy?rev=5c52d6c2172ba76267fd79b74f406fc74a50744d#5c52d6c2172ba76267fd79b74f406fc74a50744d"
 dependencies = [
  "num-traits",
 ]
@@ -647,7 +647,7 @@ dependencies = [
 [[package]]
 name = "embassy-lora"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?tag=embassy-time-v0.1.0#61560e740dea1b4c7ca036dafd66c834a1ff92e2"
+source = "git+https://github.com/embassy-rs/embassy?rev=5c52d6c2172ba76267fd79b74f406fc74a50744d#5c52d6c2172ba76267fd79b74f406fc74a50744d"
 dependencies = [
  "bit_field",
  "embassy-hal-common",
@@ -664,7 +664,7 @@ dependencies = [
 [[package]]
 name = "embassy-macros"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?tag=embassy-time-v0.1.0#61560e740dea1b4c7ca036dafd66c834a1ff92e2"
+source = "git+https://github.com/embassy-rs/embassy?rev=5c52d6c2172ba76267fd79b74f406fc74a50744d#5c52d6c2172ba76267fd79b74f406fc74a50744d"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -675,7 +675,7 @@ dependencies = [
 [[package]]
 name = "embassy-net"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?tag=embassy-time-v0.1.0#61560e740dea1b4c7ca036dafd66c834a1ff92e2"
+source = "git+https://github.com/embassy-rs/embassy?rev=5c52d6c2172ba76267fd79b74f406fc74a50744d#5c52d6c2172ba76267fd79b74f406fc74a50744d"
 dependencies = [
  "as-slice 0.2.1",
  "atomic-polyfill 1.0.1",
@@ -696,7 +696,7 @@ dependencies = [
 [[package]]
 name = "embassy-rp"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?tag=embassy-time-v0.1.0#61560e740dea1b4c7ca036dafd66c834a1ff92e2"
+source = "git+https://github.com/embassy-rs/embassy?rev=5c52d6c2172ba76267fd79b74f406fc74a50744d#5c52d6c2172ba76267fd79b74f406fc74a50744d"
 dependencies = [
  "atomic-polyfill 1.0.1",
  "cfg-if",
@@ -717,6 +717,7 @@ dependencies = [
  "embedded-hal-async",
  "embedded-hal-nb",
  "embedded-io",
+ "embedded-storage",
  "futures",
  "nb 1.0.0",
  "rp2040-pac2",
@@ -725,7 +726,7 @@ dependencies = [
 [[package]]
 name = "embassy-sync"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?tag=embassy-time-v0.1.0#61560e740dea1b4c7ca036dafd66c834a1ff92e2"
+source = "git+https://github.com/embassy-rs/embassy?rev=5c52d6c2172ba76267fd79b74f406fc74a50744d#5c52d6c2172ba76267fd79b74f406fc74a50744d"
 dependencies = [
  "atomic-polyfill 1.0.1",
  "cfg-if",
@@ -738,7 +739,7 @@ dependencies = [
 [[package]]
 name = "embassy-time"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?tag=embassy-time-v0.1.0#61560e740dea1b4c7ca036dafd66c834a1ff92e2"
+source = "git+https://github.com/embassy-rs/embassy?rev=5c52d6c2172ba76267fd79b74f406fc74a50744d#5c52d6c2172ba76267fd79b74f406fc74a50744d"
 dependencies = [
  "atomic-polyfill 1.0.1",
  "cfg-if",
@@ -753,11 +754,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "embassy-usb"
+version = "0.1.0"
+source = "git+https://github.com/embassy-rs/embassy?rev=5c52d6c2172ba76267fd79b74f406fc74a50744d#5c52d6c2172ba76267fd79b74f406fc74a50744d"
+dependencies = [
+ "embassy-futures",
+ "embassy-sync",
+ "embassy-usb-driver",
+ "heapless",
+ "ssmarshal",
+ "usbd-hid",
+]
+
+[[package]]
 name = "embassy-usb-driver"
 version = "0.1.0"
-source = "git+https://github.com/embassy-rs/embassy.git?tag=embassy-time-v0.1.0#61560e740dea1b4c7ca036dafd66c834a1ff92e2"
+source = "git+https://github.com/embassy-rs/embassy?rev=5c52d6c2172ba76267fd79b74f406fc74a50744d#5c52d6c2172ba76267fd79b74f406fc74a50744d"
 dependencies = [
  "defmt",
+]
+
+[[package]]
+name = "embassy-usb-logger"
+version = "0.1.0"
+source = "git+https://github.com/embassy-rs/embassy?rev=5c52d6c2172ba76267fd79b74f406fc74a50744d#5c52d6c2172ba76267fd79b74f406fc74a50744d"
+dependencies = [
+ "embassy-futures",
+ "embassy-sync",
+ "embassy-usb",
+ "futures",
+ "log",
+ "static_cell",
+ "usbd-hid",
 ]
 
 [[package]]
@@ -875,6 +903,12 @@ dependencies = [
  "postcard",
  "serde",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "ff"
@@ -1155,6 +1189,15 @@ checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
 dependencies = [
  "autocfg",
  "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -1553,6 +1596,7 @@ dependencies = [
  "embassy-net",
  "embassy-rp",
  "embassy-time",
+ "embassy-usb-logger",
  "embedded-hal 1.0.0-alpha.9",
  "embedded-hal-async",
  "embedded-io",
@@ -1560,6 +1604,7 @@ dependencies = [
  "embedded-tls",
  "futures",
  "heapless",
+ "log",
  "panic-probe",
  "rand",
  "rand_chacha",
@@ -1741,6 +1786,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ssmarshal"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3e6ad23b128192ed337dfa4f1b8099ced0c2bf30d61e551b65fda5916dbb850"
+dependencies = [
+ "encode_unicode",
+ "serde",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1833,6 +1888,47 @@ checksum = "7d3160b73c9a19f7e2939a2fdad446c57c1bbbbf4d919d3213ff1267a580d8b5"
 dependencies = [
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "usb-device"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f6cc3adc849b5292b4075fc0d5fdcf2f24866e88e336dd27a8943090a520508"
+
+[[package]]
+name = "usbd-hid"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "975bd411f4a939986751ea09992a24fa47c4d25c6ed108d04b4c2999a4fd0132"
+dependencies = [
+ "serde",
+ "ssmarshal",
+ "usb-device",
+ "usbd-hid-macros",
+]
+
+[[package]]
+name = "usbd-hid-descriptors"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcbee8c6735e90894fba04770bc41e11fd3c5256018856e15dc4dd1e6c8a3dd1"
+dependencies = [
+ "bitfield",
+]
+
+[[package]]
+name = "usbd-hid-macros"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "261079a9ada015fa1acac7cc73c98559f3a92585e15f508034beccf6a2ab75a2"
+dependencies = [
+ "byteorder",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+ "usbd-hid-descriptors",
 ]
 
 [[package]]

--- a/examples/rp2040/pico-w/Cargo.toml
+++ b/examples/rp2040/pico-w/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["wifi", "rpi", "networking", "iot", "picow", "cloud"]
 cyw43 = { version = "0.1.0", features = ["defmt"] }
 embassy-executor = { version = "0.1.0",  features = ["defmt", "integrated-timers"] }
 embassy-time = { version = "0.1.0",  features = ["defmt", "defmt-timestamp-uptime"] }
+embassy-usb-logger = "0.1.0"
 embassy-rp = { version = "0.1.0",  features = ["defmt", "unstable-traits", "nightly", "unstable-pac", "time-driver"] }
 embassy-net = { version = "0.1.0", features = ["defmt", "tcp", "dhcpv4", "medium-ethernet", "pool-16", "unstable-traits", "nightly"] }
 drogue-device = { version = "0.1.0", default-features = false }
@@ -37,22 +38,24 @@ embedded-tls = { version = "0.9.0", default-features = false, features = ["async
 embedded-nal-async = "0.2.0"
 rand = { version = "0.8.4", default-features = false }
 rand_chacha = { version = "0.3.1", default-features = false }
+log = "0.4"
 
 [features]
 defmt = ["dep:defmt"]
 default = ["defmt"]
 
 [patch.crates-io]
-embassy-executor = { git = "https://github.com/embassy-rs/embassy", tag = "embassy-time-v0.1.0" }
-embassy-time = { git = "https://github.com/embassy-rs/embassy", tag = "embassy-time-v0.1.0" }
-embassy-embedded-hal = { git = "https://github.com/embassy-rs/embassy", tag = "embassy-time-v0.1.0" }
-embassy-hal-common = { git = "https://github.com/embassy-rs/embassy", tag = "embassy-time-v0.1.0" }
-embassy-futures = { git = "https://github.com/embassy-rs/embassy", tag = "embassy-time-v0.1.0" }
-embassy-sync = { git = "https://github.com/embassy-rs/embassy", tag = "embassy-time-v0.1.0" }
-embassy-boot = { git = "https://github.com/embassy-rs/embassy", tag = "embassy-time-v0.1.0" }
-embassy-lora = { git = "https://github.com/embassy-rs/embassy", tag = "embassy-time-v0.1.0" }
-embassy-rp = { git = "https://github.com/embassy-rs/embassy", tag = "embassy-time-v0.1.0" }
-embassy-net = { git = "https://github.com/embassy-rs/embassy", tag = "embassy-time-v0.1.0" }
+embassy-executor = { git = "https://github.com/embassy-rs/embassy", rev = "5c52d6c2172ba76267fd79b74f406fc74a50744d" }
+embassy-time = { git = "https://github.com/embassy-rs/embassy", rev = "5c52d6c2172ba76267fd79b74f406fc74a50744d" }
+embassy-embedded-hal = { git = "https://github.com/embassy-rs/embassy", rev = "5c52d6c2172ba76267fd79b74f406fc74a50744d" }
+embassy-hal-common = { git = "https://github.com/embassy-rs/embassy", rev = "5c52d6c2172ba76267fd79b74f406fc74a50744d" }
+embassy-futures = { git = "https://github.com/embassy-rs/embassy", rev = "5c52d6c2172ba76267fd79b74f406fc74a50744d" }
+embassy-sync = { git = "https://github.com/embassy-rs/embassy", rev = "5c52d6c2172ba76267fd79b74f406fc74a50744d" }
+embassy-boot = { git = "https://github.com/embassy-rs/embassy", rev = "5c52d6c2172ba76267fd79b74f406fc74a50744d" }
+embassy-lora = { git = "https://github.com/embassy-rs/embassy", rev = "5c52d6c2172ba76267fd79b74f406fc74a50744d" }
+embassy-rp = { git = "https://github.com/embassy-rs/embassy", rev = "5c52d6c2172ba76267fd79b74f406fc74a50744d" }
+embassy-net = { git = "https://github.com/embassy-rs/embassy", rev = "5c52d6c2172ba76267fd79b74f406fc74a50744d" }
+embassy-usb-logger = { git = "https://github.com/embassy-rs/embassy", rev = "5c52d6c2172ba76267fd79b74f406fc74a50744d" }
 cyw43 = { git = "https://github.com/embassy-rs/cyw43.git", rev = "8a81114baf4ffe12ec54e80e342f098c596177d1"}
 drogue-device = { path = "../../../device" }
 

--- a/examples/rp2040/pico-w/README.adoc
+++ b/examples/rp2040/pico-w/README.adoc
@@ -9,14 +9,14 @@ It uses the on board WiFi peripheral to send data to Drogue Cloud.
 ==== Hardware
 
 * link:https://www.raspberrypi.com/products/raspberry-pi-pico/[Raspberry Pi Pico W]
-* (Recommended) An SWD debug probe (another pico) to get RTT logs
+* (Optional) A SWD debug probe
 
 ==== Software
 
 * To build the example, you need to have link:https://rustup.rs/[rustup].
-* To flash the example on the device, you need `probe-run` installed (`cargo install probe-run`).
+* To flash the example using a debug probe, you need `probe-run` installed (`cargo install probe-run`).
+* To flash the example using the UF2 bootloader on the pico, you can use the link:https://github.com/JoNil/elf2uf2-rs[elf2uf2] utility to convert the elf file into a .uf2 file that you can copy to the pico USB drive.
 * A Drogue Cloud instance. See link:https://github.com/drogue-iot/drogue-cloud/[drogue-cloud] for how to run that, or use the link:https://sandbox.drogue.cloud/[sandbox] (requires TLS).
-* (Optional) If you do not have an SWD debug probe, you can use the link:https://github.com/JoNil/elf2uf2-rs[elf2uf2] utility to convert the elf file into a .uf2 image you can flash using the builting UF2 bootloader of the pico.
 
 
 === Configuring
@@ -48,29 +48,63 @@ username = "device1@wifi-workshop"
 password = "mysecretpassword"
 ```
 
-== Running
+== Running with debug probe
 
-=== Flashing WiFi driver
+.Procedure
 
-Before running the application for the first time, you must flash the WiFi driver blob.
-
-Download firmware from link:https://github.com/embassy-rs/cyw43/tree/master/firmware[]
-, and flash them with probe-rs-cli:
-
-````rust
+. Download the WiFi firmware from link:https://github.com/embassy-rs/cyw43/tree/master/firmware[], and flash them with probe-rs-cli:
++
+----
 probe-rs-cli download 43439A0.bin --format bin --chip RP2040 --base-address 0x10100000
 probe-rs-cli download 43439A0.clm_blob --format bin --chip RP2040 --base-address 0x10140000
-````
+----
 
-=== Running the application
-
-To run the application, connect your debug probe and run:
-
-....
+. Connect your debug probe and run:
++
+----
 cargo run --release
-....
-
+----
++
 Once flashed, the device will attempt to join the WiFi network and send telemetry data to Drogue Cloud every 30 seconds.
+
+== Running with UF2 image
+
+.Procedure
+
+. Download the WiFi firmware from link:https://github.com/embassy-rs/cyw43/tree/master/firmware[], and modify main.rs to include it:
++
+----
+// let fw = unsafe { core::slice::from_raw_parts(0x10100000 as *const u8, 224190) };
+// let clm = unsafe { core::slice::from_raw_parts(0x10140000 as *const u8, 4752) };
+let fw = include_bytes!("../firmware/43439A0.bin");
+let clm = include_bytes!("../firmware/43439A0_clm.bin");
+----
+
+. Build the firmware
++
+----
+cargo build --release
+----
+
+. Convert the ELF output to UF2
++
+----
+elf2uf2-rs target/thumbv6m-none-eabi/release/rp2040-pico-w rp2040-pico-w.uf2
+----
+
+. Hold the Pico W button while powering up the board, and copy the uf2 file to the USB partition
++
+----
+cp rp2040-pico-w.uf2 /mount/point/of/usb/drive
+----
++
+Once flashed, the device will attempt to join the WiFi network and send telemetry data to Drogue Cloud every 30 seconds.
+
+. You can monitor the logs using a terminal emulator on the Pico W TTY
++
+----
+minicom -D /dev/ttyACM0
+----
 
 == Troubleshooting
 

--- a/examples/rp2040/pico-w/src/fmt.rs
+++ b/examples/rp2040/pico-w/src/fmt.rs
@@ -1,0 +1,61 @@
+#![macro_use]
+#![allow(unused_macros)]
+
+macro_rules! panic {
+    ($($x:tt)*) => {
+        {
+            ::defmt::panic!($($x)*);
+        }
+    };
+}
+
+macro_rules! trace {
+    ($s:literal $(, $x:expr)* $(,)?) => {
+        {
+            ::log::trace!($s $(, $x)*);
+            ::defmt::trace!($s $(, $x)*);
+        }
+    };
+}
+
+macro_rules! debug {
+    ($s:literal $(, $x:expr)* $(,)?) => {
+        {
+            ::log::debug!($s $(, $x)*);
+            ::defmt::debug!($s $(, $x)*);
+        }
+    };
+}
+
+macro_rules! info {
+    ($s:literal $(, $x:expr)* $(,)?) => {
+        {
+            ::log::info!($s $(, $x)*);
+            ::defmt::info!($s $(, $x)*);
+        }
+    };
+}
+
+macro_rules! warn {
+    ($s:literal $(, $x:expr)* $(,)?) => {
+        {
+            ::log::warn!($s $(, $x)*);
+            ::defmt::warn!($s $(, $x)*);
+        }
+    };
+}
+
+macro_rules! error {
+    ($s:literal $(, $x:expr)* $(,)?) => {
+        {
+            ::log::error!($s $(, $x)*);
+            ::defmt::error!($s $(, $x)*);
+        }
+    };
+}
+
+macro_rules! unwrap {
+    ($($x:tt)*) => {
+        ::defmt::unwrap!($($x)*)
+    };
+}


### PR DESCRIPTION
Enables the new USB logger from embassy to make the example log output to USB serial so that it can be used without a debug probe.