### PR TITLE
Move QSPI interrupt initialization out of the configure method

### DIFF
--- a/boards/adafruit-feather-nrf52/src/board.rs
+++ b/boards/adafruit-feather-nrf52/src/board.rs
@@ -53,12 +53,11 @@ mod express {
 
     impl ExternalFlashPins {
         /// Configure an external flash instance based on pins
-        pub fn configure<'d>(self) -> ExternalFlash<'d> {
+        pub fn configure<'d>(self, irq: interrupt::QSPI) -> ExternalFlash<'d> {
             let mut config = qspi::Config::default();
             config.read_opcode = qspi::ReadOpcode::READ4IO;
             config.write_opcode = qspi::WriteOpcode::PP4O;
             config.write_page_size = qspi::WritePageSize::_256BYTES;
-            let irq = interrupt::take!(QSPI);
             let mut q: qspi::Qspi<'_, _, EXTERNAL_FLASH_SIZE> = qspi::Qspi::new(
                 self.qspi, irq, self.sck, self.csn, self.io0, self.io1, self.io2, self.io3, config,
             );

--- a/examples/nrf52/adafruit-feather-nrf52840/boot/src/main.rs
+++ b/examples/nrf52/adafruit-feather-nrf52840/boot/src/main.rs
@@ -24,7 +24,7 @@ fn main() -> ! {
     let mut bl = BootLoader::default();
 
     let board = AdafruitFeatherNrf52::default();
-    let qspi = board.external_flash.configure();
+    let qspi = board.external_flash.configure(interrupt::take!(QSPI));
     let nvmc = WatchdogFlash::start(Nvmc::new(board.nvmc), board.wdt, 5);
     let nvmc = BootFlash::new(nvmc);
     let qspi = BootFlash::new(qspi);


### PR DESCRIPTION
This allows for configuring the interrupt priority when running with softdevice, as well as avoids duplicate symbol error when the original configure method is in scope.